### PR TITLE
Allow non-tuple members in lists:keyfind/3

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -5131,7 +5131,7 @@ static term nif_lists_keyfind(Context *ctx, int argc, term argv[])
     }
 
     int n_pos = term_to_int(n);
-    
+
     if (n_pos <= 0) {
         RAISE_ERROR(BADARG_ATOM);
     }
@@ -5146,7 +5146,8 @@ static term nif_lists_keyfind(Context *ctx, int argc, term argv[])
         term tuple = term_get_list_head(tuple_list);
 
         if (!term_is_tuple(tuple)) {
-            RAISE_ERROR(BADARG_ATOM);
+            tuple_list = term_get_list_tail(tuple_list);
+            continue;
         }
 
         int tuple_size = term_get_tuple_arity(tuple);


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
