### PR TITLE
Add ets:take

### DIFF
--- a/libs/estdlib/src/ets.erl
+++ b/libs/estdlib/src/ets.erl
@@ -34,7 +34,8 @@
     delete_object/2,
     update_counter/3,
     update_counter/4,
-    update_element/3
+    update_element/3,
+    take/2
 ]).
 
 -export_type([
@@ -184,4 +185,18 @@ delete_object(_Table, _Key) ->
     Changes :: [{pos_integer(), Value :: term()}]
 ) -> boolean().
 update_element(_Table, _Key, _Changes) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @param Table a reference to the ets table
+%% @param Key the key associated with the object to delete and return.
+%% @returns deleted element.
+%% @doc Removes an object from ets table and returns it.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec take(
+    Table :: table(),
+    Key :: term()
+) -> term().
+take(_Table, _Key) ->
     erlang:nif_error(undefined).

--- a/src/libAtomVM/ets.c
+++ b/src/libAtomVM/ets.c
@@ -619,3 +619,28 @@ EtsErrorCode ets_update_element(term ref, term key, term value, term pos, term *
     *ret = TRUE_ATOM;
     return insert_result;
 }
+
+EtsErrorCode ets_take(term ref, term key, term *ret, Context *ctx)
+{
+    struct EtsTable *ets_table = term_is_atom(ref) ? ets_get_table_by_name(&ctx->global->ets, ref, TableAccessWrite) : ets_get_table_by_ref(&ctx->global->ets, term_to_ref_ticks(ref), TableAccessWrite);
+    if (ets_table == NULL) {
+        return EtsTableNotFound;
+    }
+
+    term to_return = term_invalid_term();
+    EtsErrorCode result = ets_table_lookup(ets_table, key, &to_return, ctx);
+    if (result != EtsOk) {
+        SMP_UNLOCK(ets_table);
+        return result;
+    }
+    *ret = to_return;
+    if (term_is_nil(to_return)) {
+        SMP_UNLOCK(ets_table);
+        return EtsOk;
+    }
+
+    term del_result;
+    EtsErrorCode res = ets_table_delete(ets_table, key, &del_result, ctx);
+    SMP_UNLOCK(ets_table);
+    return res;
+}

--- a/src/libAtomVM/ets.h
+++ b/src/libAtomVM/ets.h
@@ -81,6 +81,7 @@ EtsErrorCode ets_update_counter(term ref, term key, term operation, term default
 EtsErrorCode ets_insert_new(term ref, term tuple, term *ret, Context *ctx);
 EtsErrorCode ets_delete_object(term ref, term tuple, term *ret, Context *ctx);
 EtsErrorCode ets_update_element(term ref, term key, term value, term pos, term *ret, Context *ctx);
+EtsErrorCode ets_take(term ref, term key, term *ret, Context *ctx);
 
 #ifdef __cplusplus
 }

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -159,6 +159,7 @@ static term nif_ets_insert_new(Context *ctx, int argc, term argv[]);
 static term nif_ets_update_counter(Context *ctx, int argc, term argv[]);
 static term nif_ets_update_element(Context *ctx, int argc, term argv[]);
 static term nif_ets_lookup(Context *ctx, int argc, term argv[]);
+static term nif_ets_take(Context *ctx, int argc, term argv[]);
 static term nif_ets_lookup_element(Context *ctx, int argc, term argv[]);
 static term nif_ets_delete(Context *ctx, int argc, term argv[]);
 static term nif_ets_delete_object(Context *ctx, int argc, term argv[]);
@@ -708,6 +709,12 @@ static const struct Nif ets_lookup_nif =
 {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_ets_lookup
+};
+
+static const struct Nif ets_take_nif =
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_ets_take
 };
 
 static const struct Nif ets_lookup_element_nif =
@@ -3402,6 +3409,30 @@ static term nif_ets_lookup(Context *ctx, int argc, term argv[])
 
     term ret = term_invalid_term();
     EtsErrorCode result = ets_lookup(ref, key, &ret, ctx);
+    switch (result) {
+        case EtsOk:
+            return ret;
+        case EtsTableNotFound:
+        case EtsPermissionDenied:
+            RAISE_ERROR(BADARG_ATOM);
+        case EtsAllocationFailure:
+            RAISE_ERROR(MEMORY_ATOM);
+        default:
+            AVM_ABORT();
+    }
+}
+
+static term nif_ets_take(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+
+    term ref = argv[0];
+    VALIDATE_VALUE(ref, is_ets_table_id);
+
+    term key = argv[1];
+
+    term ret = term_invalid_term();
+    EtsErrorCode result = ets_take(ref, key, &ret, ctx);
     switch (result) {
         case EtsOk:
             return ret;

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -134,6 +134,7 @@ ets:insert_new/2, &ets_insert_new_nif
 ets:update_counter/3, &ets_update_counter_nif
 ets:update_counter/4, &ets_update_counter_nif
 ets:update_element/3, &ets_update_element_nif
+ets:take/2, &ets_take_nif
 ets:insert/2, &ets_insert_nif
 ets:lookup/2, &ets_lookup_nif
 ets:lookup_element/3, &ets_lookup_element_nif

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -35,6 +35,7 @@ start() ->
     ok = test_update_counter(),
     ok = test_update_element(),
     ok = test_delete_object(),
+    ok = test_take(),
 
     0.
 
@@ -402,4 +403,13 @@ test_delete_object() ->
     [{foo, 1, 2, 3}] = ets:lookup(Tid, foo),
     true = ets:delete_object(Tid, {foo, 1, 2, 3}),
     [] = ets:lookup(Tid, foo),
+    ok.
+
+test_take() ->
+    Tid = ets:new(test_take, []),
+    true = ets:insert(Tid, {foo, 1, 2, 3}),
+    [{foo, 1, 2, 3}] = ets:take(Tid, foo),
+    [] = ets:take(Tid,foo),
+    [] = ets:lookup(Tid, foo),
+    [] = ets:take(Tid, tapas),
     ok.


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
Added nif for ets:take/2.
https://www.erlang.org/docs/23/man/ets#take-2