### PR TITLE
Fix alloc in lists:subtract/2

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -5566,7 +5566,7 @@ static term nif_erlang_lists_subtract(Context *ctx, int argc, term argv[])
         return list1;
     }
 
-    term *cons = malloc(len * sizeof(term_get_list_head));
+    term *cons = malloc(len * sizeof(term));
     if (UNLIKELY(IS_NULL_PTR(cons))) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
