### PR TITLE
Fixed ets_update_counter

### DIFF
--- a/src/libAtomVM/ets.c
+++ b/src/libAtomVM/ets.c
@@ -546,7 +546,7 @@ EtsErrorCode ets_update_counter(term ref, term key, term operation, term default
     }
     int arity = term_get_tuple_arity(to_insert);
     int position = term_to_int(position_term) - 1;
-    if (arity < position || position < 1) {
+    if (arity <= position || position < 1) {
         SMP_UNLOCK(ets_table);
         return EtsBadEntry;
     }


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
Fixed error that occured when element to update  == arity.