### PR TITLE
Add ets:lookup_element/4

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3670,8 +3670,6 @@ static term nif_ets_update_element(Context *ctx, int argc, term argv[])
 
 static term nif_ets_lookup_element(Context *ctx, int argc, term argv[])
 {
-    UNUSED(argc);
-
     term ref = argv[0];
     VALIDATE_VALUE(ref, is_ets_table_id);
 
@@ -3679,12 +3677,20 @@ static term nif_ets_lookup_element(Context *ctx, int argc, term argv[])
     term pos = argv[2];
     VALIDATE_VALUE(pos, term_is_integer);
 
+    term default_value = term_invalid_term();
+    if (argc == 4) {
+        default_value = argv[3];
+    }
+
     term ret = term_invalid_term();
     EtsErrorCode result = ets_lookup_element(ref, key, term_to_int(pos), &ret, ctx);
     switch (result) {
         case EtsOk:
             return ret;
         case EtsEntryNotFound:
+            if (!term_is_invalid_term(default_value)) {
+                return default_value;
+            }
         case EtsBadPosition:
         case EtsTableNotFound:
         case EtsPermissionDenied:

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -141,6 +141,7 @@ ets:member/2, &ets_member_nif
 ets:insert/2, &ets_insert_nif
 ets:lookup/2, &ets_lookup_nif
 ets:lookup_element/3, &ets_lookup_element_nif
+ets:lookup_element/4, &ets_lookup_element_nif
 ets:delete/2, &ets_delete_nif
 ets:delete_object/2, &ets_delete_object_nif
 atomvm:add_avm_pack_binary/2, &atomvm_add_avm_pack_binary_nif

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -354,6 +354,8 @@ test_lookup_element() ->
     true = ets:insert(Tid, {foo, tapas}),
     foo = ets:lookup_element(Tid, foo, 1),
     tapas = ets:lookup_element(Tid, foo, 2),
+    tapas = ets:lookup_element(Tid, foo, 2, batat),
+    batat = ets:lookup_element(Tid, bar, 1, batat),
     expect_failure(fun() -> ets:lookup_element(Tid, bar, 1) end),
     expect_failure(fun() -> ets:lookup_element(Tid, foo, 3) end),
     expect_failure(fun() -> ets:lookup_element(Tid, foo, 0) end),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

Added option to handle default value in ets:lookup_element.
https://www.erlang.org/docs/26/man/ets#lookup_element-4

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
