### PR TITLE
Modify ets:insert to work with lists

### DIFF
--- a/libs/estdlib/src/ets.erl
+++ b/libs/estdlib/src/ets.erl
@@ -70,7 +70,7 @@ new(_Name, _Options) ->
 %% @doc Insert an entry into an ets table.
 %% @end
 %%-----------------------------------------------------------------------------
--spec insert(Table :: table(), Entry :: tuple()) -> true.
+-spec insert(Table :: table(), Entry :: tuple() | [tuple()]) -> true.
 insert(_Table, _Entry) ->
     erlang:nif_error(undefined).
 

--- a/src/libAtomVM/ets.c
+++ b/src/libAtomVM/ets.c
@@ -285,14 +285,37 @@ EtsErrorCode ets_table_insert(struct EtsTable *ets_table, term entry, Context *c
     return result;
 }
 
+EtsErrorCode ets_table_insert_list(struct EtsTable *ets_table, term list, Context *ctx)
+{
+    while (term_is_nonempty_list(list)) {
+        term tuple = term_get_list_head(list);
+        if (!term_is_tuple(tuple) && term_get_tuple_arity(tuple) < 1) {
+            return EtsBadEntry;
+        }
+        EtsErrorCode result = ets_table_insert(ets_table, tuple, ctx);
+        if (result != EtsOk) {
+            AVM_ABORT(); // Abort because operation might not be atomic.
+        }
+
+        list = term_get_list_tail(list);
+    }
+
+    return EtsOk;
+}
+
 EtsErrorCode ets_insert(term ref, term entry, Context *ctx)
 {
     struct EtsTable *ets_table = term_is_atom(ref) ? ets_get_table_by_name(&ctx->global->ets, ref, TableAccessWrite) : ets_get_table_by_ref(&ctx->global->ets, term_to_ref_ticks(ref), TableAccessWrite);
     if (ets_table == NULL) {
         return EtsTableNotFound;
     }
+    EtsErrorCode result = EtsBadEntry;
 
-    EtsErrorCode result = ets_table_insert(ets_table, entry, ctx);
+    if (term_is_tuple(entry) && term_get_tuple_arity(entry) > 0) {
+        result = ets_table_insert(ets_table, entry, ctx);
+    } else if (term_is_list(entry)) {
+        result = ets_table_insert_list(ets_table, entry, ctx);
+    }
 
     SMP_UNLOCK(ets_table);
 

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -3485,10 +3485,6 @@ static term nif_ets_insert(Context *ctx, int argc, term argv[])
     VALIDATE_VALUE(ref, is_ets_table_id);
 
     term entry = argv[1];
-    VALIDATE_VALUE(entry, term_is_tuple);
-    if (term_get_tuple_arity(entry) < 1) {
-        RAISE_ERROR(BADARG_ATOM);
-    }
 
     EtsErrorCode result = ets_insert(ref, entry, ctx);
     switch (result) {

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -37,6 +37,7 @@ start() ->
     ok = test_delete_object(),
     ok = test_take(),
     ok = test_member(),
+    ok = test_insert_list(),
 
     0.
 
@@ -426,4 +427,11 @@ test_member() ->
     true = ets:insert(Tid, {foo, tapas}),
     true = ets:member(Tid, foo),
     false = ets:member(Tid, cow),
+    ok.
+
+test_insert_list() ->
+    Tid = ets:new(test_insert_list, []),
+    true = ets:insert(Tid, [{foo, tapas}, {batat, batat}, {patat, patat}]),
+    [{patat, patat}] = ets:lookup(Tid, patat),
+    [{batat, batat}] = ets:lookup(Tid, batat),
     ok.


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).
Added option to insert lists.
SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
