### PR TITLE
Enable stacktraces in WASM

### DIFF
--- a/src/platforms/emscripten/CMakeLists.txt
+++ b/src/platforms/emscripten/CMakeLists.txt
@@ -32,6 +32,7 @@ endif ()
 option(AVM_DISABLE_SMP "Disable SMP." OFF)
 option(AVM_USE_32BIT_FLOAT "Use 32 bit floats." OFF)
 option(AVM_VERBOSE_ABORT "Print module and line number on VM abort" OFF)
+option(AVM_CREATE_STACKTRACES "Create stacktraces" ON)
 
 set(
     PLATFORM_LIB_SUFFIX


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
