### PR TITLE
Move md5 to stdlib nifs from emscripten platform nifs

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -47,6 +47,7 @@
 #include "globalcontext.h"
 #include "interop.h"
 #include "mailbox.h"
+#include "md5.h"
 #include "memory.h"
 #include "module.h"
 #include "platform_nifs.h"
@@ -182,6 +183,7 @@ static term nif_erlang_memory(Context *ctx, int argc, term argv[]);
 static term nif_erlang_monitor(Context *ctx, int argc, term argv[]);
 static term nif_erlang_demonitor(Context *ctx, int argc, term argv[]);
 static term nif_erlang_unlink(Context *ctx, int argc, term argv[]);
+static term nif_erlang_md5(Context *ctx, int argc, term argv[]);
 static term nif_atomvm_add_avm_pack_binary(Context *ctx, int argc, term argv[]);
 static term nif_atomvm_add_avm_pack_file(Context *ctx, int argc, term argv[]);
 static term nif_atomvm_close_avm_pack(Context *ctx, int argc, term argv[]);
@@ -694,6 +696,11 @@ static const struct Nif raise_nif =
 {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_erlang_raise
+};
+
+static const struct Nif md5_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_erlang_md5
 };
 
 static const struct Nif ets_new_nif =
@@ -4364,6 +4371,57 @@ static term nif_erlang_get_module_info(Context *ctx, int argc, term argv[])
     result = term_list_prepend(module_tuple, result, &ctx->heap);
 
     return result;
+}
+
+static InteropFunctionResult md5_hash_vendored_fold_fun(term t, void *accum)
+{
+    MD5Context *ctx = (MD5Context *) accum;
+    if (term_is_integer(t)) {
+        avm_int64_t tmp = term_maybe_unbox_int64(t);
+        if (tmp < 0 || tmp > 255) {
+            return InteropBadArg;
+        }
+        uint8_t val = (uint8_t) tmp;
+        md5Update(ctx, &val, 1);
+    } else /* term_is_binary(t) */ {
+        md5Update(ctx, (uint8_t *) term_binary_data(t), term_binary_size(t));
+    }
+    return InteropOk;
+}
+
+static bool do_md5_hash_vendored(term data, unsigned char *dst)
+{
+    MD5Context ctx;
+    md5Init(&ctx);
+
+    InteropFunctionResult result = interop_chardata_fold(data, md5_hash_vendored_fold_fun, NULL, (void *) &ctx);
+    if (UNLIKELY(result != InteropOk)) {
+        return false;
+    }
+
+    md5Finalize(&ctx);
+    memcpy(dst, ctx.digest, 16);
+
+    return true;
+}
+
+#define MAX_MD_SIZE 64
+static term nif_erlang_md5(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    term data = argv[0];
+
+    unsigned char digest[MAX_MD_SIZE];
+    size_t digest_len = 16;
+
+    if (UNLIKELY(!do_md5_hash_vendored(data, digest))) {
+        RAISE_ERROR(BADARG_ATOM)
+    }
+
+    if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(digest_len)) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    return term_from_literal_binary(digest, digest_len, &ctx->heap, ctx->global);
 }
 
 struct RefcBinaryAVMPack

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -130,6 +130,7 @@ erlang:group_leader/0, &group_leader_nif
 erlang:group_leader/2, &group_leader_nif
 erlang:get_module_info/1, &get_module_info_nif
 erlang:get_module_info/2, &get_module_info_nif
+erlang:md5/1, &md5_nif
 erts_debug:flat_size/1, &flat_size_nif
 ets:new/2, &ets_new_nif
 ets:insert_new/2, &ets_insert_new_nif

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -40,7 +40,6 @@
 #include <trace.h>
 
 #include "emscripten_sys.h"
-#include "md5.h"
 #include "memory.h"
 #include "platform_defaultatoms.h"
 #include "platform_nifs.h"
@@ -759,67 +758,8 @@ HTML5_REGISTER_CALLBACK(touch, EMSCRIPTEN_EVENT_TOUCHCANCEL, touchcancel);
         return &emscripten_unregister_##callback##_callback_nif;       \
     }
 
-static InteropFunctionResult md5_hash_vendored_fold_fun(term t, void *accum)
-{
-    MD5Context *ctx = (MD5Context *) accum;
-    if (term_is_integer(t)) {
-        avm_int64_t tmp = term_maybe_unbox_int64(t);
-        if (tmp < 0 || tmp > 255) {
-            return InteropBadArg;
-        }
-        uint8_t val = (uint8_t) tmp;
-        md5Update(ctx, &val, 1);
-    } else /* term_is_binary(t) */ {
-        md5Update(ctx, (uint8_t *) term_binary_data(t), term_binary_size(t));
-    }
-    return InteropOk;
-}
-
-static bool do_md5_hash_vendored(term data, unsigned char *dst)
-{
-    MD5Context ctx;
-    md5Init(&ctx);
-
-    InteropFunctionResult result = interop_chardata_fold(data, md5_hash_vendored_fold_fun, NULL, (void *) &ctx);
-    if (UNLIKELY(result != InteropOk)) {
-        return false;
-    }
-
-    md5Finalize(&ctx);
-    memcpy(dst, ctx.digest, 16);
-
-    return true;
-}
-
-#define MAX_MD_SIZE 64
-static term nif_crypto_md5_vendored_hash(Context *ctx, int argc, term argv[])
-{
-    UNUSED(argc);
-    term data = argv[0];
-
-    unsigned char digest[MAX_MD_SIZE];
-    size_t digest_len = 16;
-
-    if (UNLIKELY(!do_md5_hash_vendored(data, digest))) {
-        RAISE_ERROR(BADARG_ATOM)
-    }
-
-    if (UNLIKELY(memory_ensure_free(ctx, term_binary_heap_size(digest_len)) != MEMORY_GC_OK)) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-    }
-    return term_from_literal_binary(digest, digest_len, &ctx->heap, ctx->global);
-}
-
-static const struct Nif crypto_md5_vendored_hash_nif = {
-    .base.type = NIFFunctionType,
-    .nif_ptr = nif_crypto_md5_vendored_hash
-};
-
 const struct Nif *platform_nifs_get_nif(const char *nifname)
 {
-    if (strcmp("erlang:md5/1", nifname) == 0) {
-        return &crypto_md5_vendored_hash_nif;
-    }
     if (strcmp("atomvm:platform/0", nifname) == 0) {
         return &atomvm_platform_nif;
     }


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
