### PR TITLE
Add binary_part/3 to BIFs

### DIFF
--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -114,6 +114,37 @@ term bif_erlang_bit_size_1(Context *ctx, uint32_t fail_label, int live, term arg
     return term_from_int32(len);
 }
 
+term bif_erlang_binary_part_3(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2, term arg3)
+{
+    UNUSED(live);
+    VALIDATE_VALUE_BIF(fail_label, arg1, term_is_binary);
+    VALIDATE_VALUE_BIF(fail_label, arg2, term_is_integer);
+    VALIDATE_VALUE_BIF(fail_label, arg3, term_is_integer);
+
+    term bin_term = arg1;
+    term pos_term = arg2;
+    term len_term = arg3;
+
+    int bin_size = term_binary_size(bin_term);
+    avm_int_t pos = term_to_int(pos_term);
+    avm_int_t len = term_to_int(len_term);
+
+    if (len < 0) {
+        pos += len;
+        len = -len;
+    }
+
+    if (UNLIKELY((pos < 0) || (pos > bin_size) || (pos + len > bin_size))) {
+        RAISE_ERROR_BIF(fail_label, BADARG_ATOM);
+    }
+
+    size_t size = term_sub_binary_heap_size(bin_term, len);
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, size, 1, &bin_term, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        RAISE_ERROR_BIF(fail_label, OUT_OF_MEMORY_ATOM);
+    }
+    return term_maybe_create_sub_binary(bin_term, pos, len, &ctx->heap, ctx->global);
+}
+
 term bif_erlang_is_atom_1(Context *ctx, uint32_t fail_label, term arg1)
 {
     UNUSED(ctx);

--- a/src/libAtomVM/bif.h
+++ b/src/libAtomVM/bif.h
@@ -44,6 +44,7 @@ const struct ExportedFunction *bif_registry_get_handler(AtomString module, AtomS
 term bif_erlang_self_0(Context *ctx);
 term bif_erlang_byte_size_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 term bif_erlang_bit_size_1(Context *ctx, uint32_t fail_label, int live, term arg1);
+term bif_erlang_binary_part_3(Context *ctx, uint32_t fail_label, int live, term arg1, term arg2, term arg3);
 term bif_erlang_length_1(Context *ctx, uint32_t fail_label, int live, term arg1);
 
 term bif_erlang_is_atom_1(Context *ctx, uint32_t fail_label, term arg1);

--- a/src/libAtomVM/bifs.gperf
+++ b/src/libAtomVM/bifs.gperf
@@ -39,6 +39,7 @@ erlang:self/0, {.bif.base.type = BIFFunctionType, .bif.bif0_ptr = bif_erlang_sel
 erlang:length/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_length_1}
 erlang:byte_size/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_byte_size_1}
 erlang:bit_size/1, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif1_ptr = bif_erlang_bit_size_1}
+erlang:binary_part/3, {.gcbif.base.type = GCBIFFunctionType, .gcbif.gcbif3_ptr = bif_erlang_binary_part_3}
 erlang:get/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_get_1}
 erlang:is_atom/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_atom_1}
 erlang:is_bitstring/1, {.bif.base.type = BIFFunctionType, .bif.bif1_ptr = bif_erlang_is_binary_1}


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
