### PR TITLE
Allow caching .avm file when fetching it from server in emscripten

### DIFF
--- a/src/platforms/emscripten/src/lib/sys.c
+++ b/src/platforms/emscripten/src/lib/sys.c
@@ -600,6 +600,8 @@ static emscripten_fetch_t *fetch_file(const char *url)
     emscripten_fetch_attr_t attr;
     emscripten_fetch_attr_init(&attr);
     strcpy(attr.requestMethod, "GET");
+    const char *headers[] = { "Cache-Control", "max-age=604800", NULL };
+    attr.requestHeaders = headers;
     attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY | EMSCRIPTEN_FETCH_SYNCHRONOUS;
     emscripten_fetch_t *fetch = emscripten_fetch(&attr, url);
     if (fetch->status == 200) {


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
