### PR TITLE
Fix obvious memory leak

### DIFF
--- a/tools/packbeam/packbeam.c
+++ b/tools/packbeam/packbeam.c
@@ -265,12 +265,14 @@ static int do_pack(int argc, char **argv, int is_archive, bool include_lines)
         if (avmpack_is_valid(file_data, file_size)) {
             void *result = avmpack_fold(pack, file_data, pack_beam_fun);
             if (result == NULL) {
+                free(file_data);
                 return EXIT_FAILURE;
             }
         } else {
             char *filename = basename(argv[i]);
             pack_beam_file(pack, file_data, file_size, filename, !is_archive && i == 1, include_lines);
         }
+        free(file_data);
     }
 
     add_module_header(pack, "end", END_OF_FILE);


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
