### PR TITLE
Remove UB from prim_file:get_cwd/0

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -5987,22 +5987,18 @@ static term nif_erlang_lists_subtract(Context *ctx, int argc, term argv[])
     return result;
 }
 
-
 static term nif_prim_file_get_cwd_0(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc)
     UNUSED(argv)
-    char cwd[PATH_MAX];
-    if (UNLIKELY(IS_NULL_PTR(cwd))) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-    }
 
     if (UNLIKELY(memory_ensure_free(ctx, TUPLE_SIZE(2)) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
     term result_tuple = term_alloc_tuple(2, &ctx->heap);
 
-    if (UNLIKELY(IS_NULL_PTR(getcwd(cwd, PATH_MAX)))) {
+    char cwd[PATH_MAX];
+    if (IS_NULL_PTR(getcwd(cwd, PATH_MAX))) {
         term reason = UNDEFINED_ATOM;
         switch (errno) {
             case EACCES:
@@ -6027,10 +6023,10 @@ static term nif_prim_file_get_cwd_0(Context *ctx, int argc, term argv[])
     if (UNLIKELY(memory_ensure_free_with_roots(ctx, term_binary_heap_size(cwd_length), 1, &result_tuple, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
-    term result = term_from_literal_binary(cwd, cwd_length, &ctx->heap, ctx->global);
+    term cwd_binary = term_from_literal_binary(cwd, cwd_length, &ctx->heap, ctx->global);
 
     term_put_tuple_element(result_tuple, 0, OK_ATOM);
-    term_put_tuple_element(result_tuple, 1, result);
+    term_put_tuple_element(result_tuple, 1, cwd_binary);
     return result_tuple;
 }
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
