### PR TITLE
Fix SEGFAULT in nif_lists_reverse

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -5504,7 +5504,7 @@ static term nif_lists_reverse(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    if (UNLIKELY(memory_ensure_free_with_roots(ctx, len * CONS_SIZE, 2, argv, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, len * CONS_SIZE, argc, argv, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 


### PR DESCRIPTION
A hardcoded `2` as roots count is invalid when nif is called as lists:reverse/1

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
