### PR TITLE
Downstreamed erlang:get/0 and erlang:erase/0 functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `net:gethostname/0` on platforms with gethostname(3).
 - Added `socket:getopt/2`
 - Added `supervisor:terminate_child/2`, `supervisor:restart_child/2` and `supervisor:delete_child/2`
+- Added `erlang:get/0` and `erlang:erase/0`.
 
 ### Fixed
 - ESP32: improved sntp sync speed from a cold boot.

--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -44,8 +44,10 @@
     min/2,
     max/2,
     memory/1,
+    get/0,
     get/1,
     put/2,
+    erase/0,
     erase/1,
     function_exported/3,
     display/1,
@@ -526,6 +528,15 @@ monotonic_time(_Unit) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------
+%% @returns the process directory
+%% @doc     Return all values from the process dictionary
+%% @end
+%%-----------------------------------------------------------------------------
+-spec get() -> [{any(), any()}].
+get() ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
 %% @param   Key     key in the process dictionary
 %% @returns value associated with this key or undefined
 %% @doc     Return a value associated with a given key in the process dictionary
@@ -544,6 +555,15 @@ get(_Key) ->
 %%-----------------------------------------------------------------------------
 -spec put(Key :: any(), Value :: any()) -> any().
 put(_Key, _Value) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns the previous process dictionary.
+%% @doc     Erase all keys from the process dictionary.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec erase() -> [{any(), any()}].
+erase() ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -125,6 +125,7 @@ static term nif_erlang_binary_to_list_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_binary_to_existing_atom_2(Context *ctx, int argc, term argv[]);
 static term nif_erlang_concat_2(Context *ctx, int argc, term argv[]);
 static term nif_erlang_display_1(Context *ctx, int argc, term argv[]);
+static term nif_erlang_erase_0(Context *ctx, int argc, term argv[]);
 static term nif_erlang_erase_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_error(Context *ctx, int argc, term argv[]);
 static term nif_erlang_exit(Context *ctx, int argc, term argv[]);
@@ -166,6 +167,7 @@ static term nif_erlang_process_flag(Context *ctx, int argc, term argv[]);
 static term nif_erlang_processes(Context *ctx, int argc, term argv[]);
 static term nif_erlang_process_info(Context *ctx, int argc, term argv[]);
 static term nif_erlang_fun_info_2(Context *ctx, int argc, term argv[]);
+static term nif_erlang_get_0(Context *ctx, int argc, term argv[]);
 static term nif_erlang_put_2(Context *ctx, int argc, term argv[]);
 static term nif_erlang_system_info(Context *ctx, int argc, term argv[]);
 static term nif_erlang_system_flag(Context *ctx, int argc, term argv[]);
@@ -372,8 +374,12 @@ static const struct Nif display_nif =
     .nif_ptr = nif_erlang_display_1
 };
 
-static const struct Nif erase_nif =
-{
+static const struct Nif erase_0_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_erlang_erase_0
+};
+
+static const struct Nif erase_1_nif = {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_erlang_erase_1
 };
@@ -615,6 +621,11 @@ static const struct Nif process_info_nif =
 {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_erlang_process_info
+};
+
+static const struct Nif get_0_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_erlang_get_0
 };
 
 static const struct Nif put_nif =
@@ -4470,6 +4481,32 @@ static term nif_erlang_fun_info_2(Context *ctx, int argc, term argv[])
     return fun_info_tuple;
 }
 
+static term nif_erlang_get_0(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    UNUSED(argv);
+
+    term result = term_nil();
+    size_t size = 0;
+    struct ListHead *dictionary = &ctx->dictionary;
+    struct ListHead *item;
+    LIST_FOR_EACH (item, dictionary) {
+        size++;
+    }
+    if (UNLIKELY(memory_ensure_free(ctx, LIST_SIZE(size, TUPLE_SIZE(2))) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    LIST_FOR_EACH (item, dictionary) {
+        struct DictEntry *dict_entry = GET_LIST_ENTRY(item, struct DictEntry, head);
+        term tuple = term_alloc_tuple(2, &ctx->heap);
+        term_put_tuple_element(tuple, 0, dict_entry->key);
+        term_put_tuple_element(tuple, 1, dict_entry->value);
+        result = term_list_prepend(tuple, result, &ctx->heap);
+    }
+
+    return result;
+}
+
 static term nif_erlang_put_2(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc);
@@ -4481,6 +4518,19 @@ static term nif_erlang_put_2(Context *ctx, int argc, term argv[])
     }
 
     return old;
+}
+
+static term nif_erlang_erase_0(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+
+    term result = nif_erlang_get_0(ctx, argc, argv);
+    if (LIKELY(!term_is_invalid_term(result))) {
+        dictionary_destroy(&ctx->dictionary);
+        list_init(&ctx->dictionary);
+    }
+
+    return result;
 }
 
 static term nif_erlang_erase_1(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -59,7 +59,8 @@ erlang:binary_to_list/1, &binary_to_list_nif
 erlang:binary_to_existing_atom/1, &binary_to_existing_atom_nif
 erlang:binary_to_existing_atom/2, &binary_to_existing_atom_nif
 erlang:delete_element/2, &delete_element_nif
-erlang:erase/1, &erase_nif
+erlang:erase/0, &erase_0_nif
+erlang:erase/1, &erase_1_nif
 erlang:error/1, &error_nif
 erlang:error/2, &error_nif
 erlang:error/3, &error_nif
@@ -118,6 +119,7 @@ erlang:process_flag/2, &process_flag_nif
 erlang:process_flag/3, &process_flag_nif
 erlang:processes/0, &processes_nif
 erlang:process_info/2, &process_info_nif
+erlang:get/0, &get_0_nif
 erlang:put/2, &put_nif
 erlang:binary_to_term/1, &binary_to_term_nif
 erlang:binary_to_term/2, &binary_to_term_nif

--- a/tests/erlang_tests/test_dict.erl
+++ b/tests/erlang_tests/test_dict.erl
@@ -23,6 +23,7 @@
 -export([start/0, put_int/1, stringize/1, factorial/1, id/1, the_get/1, the_erase/1]).
 
 start() ->
+    ok = test_get_0_erase_0(),
     put_int(0),
     X = put_int(1),
     put_int(2),
@@ -79,4 +80,13 @@ test_put_get_erase() ->
     2 = apply(erlang, list_to_atom("get"), [{any_term}]),
     2 = apply(erlang, list_to_atom("erase"), [{any_term}]),
     undefined = erase({any_term}),
+    ok.
+
+test_get_0_erase_0() ->
+    [] = get(),
+    undefined = put({any_term}, 1),
+    [{{any_term}, 1}] = get(),
+    [{{any_term}, 1}] = erase(),
+    [] = get(),
+    [] = erase(),
     ok.


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
