### PR TITLE
Fixed outdated CI - new name and mix commands for popcorn tests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -48,12 +48,13 @@ jobs:
       #     tests/test-enif
       #     tests/test-mailbox
       #     tests/test-structs
-      - name: Build FissionLib
+      - name: Build Popcorn
         run: |
-          git clone git@github.com:software-mansion-labs/elixir-wasm.git
-          cd elixir-wasm/fission_lib
-          echo "import Config; config :fission_lib, atomvm_path: \"../../build/src/AtomVM\"" > config/config.secret.exs
+          git clone git@github.com:software-mansion/popcorn.git
+          cd popcorn
+          echo "import Config; config :popcorn, target: :unix, runtime_source: {:path, \"..\"}" > config/config.secret.exs
           mix deps.get
-          MIX_ENV=test mix compile
-      - name: Test FissionLib
-        run: cd elixir-wasm/fission_lib && mix test
+          export PATH=$PATH:/home/runner/.mix/elixir/1-17/ # for rebar3
+          MIX_ENV=test mix popcorn.build_runtime --target unix
+      - name: Test Popcorn
+        run: cd popcorn && mix test


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
