### PR TITLE
Batch JS calls

### DIFF
--- a/src/platforms/emscripten/src/CMakeLists.txt
+++ b/src/platforms/emscripten/src/CMakeLists.txt
@@ -28,8 +28,11 @@ add_subdirectory(../../../libAtomVM libAtomVM)
 target_link_libraries(AtomVM PUBLIC libAtomVM)
 target_compile_options(libAtomVM PUBLIC -O3 -fno-exceptions -fno-rtti -pthread -sINLINING_LIMIT -sUSE_ZLIB=1)
 target_compile_definitions(libAtomVM PRIVATE WITH_ZLIB)
-target_link_options(AtomVM PRIVATE -sEXPORTED_RUNTIME_METHODS=ccall,cwrap,stringToNewUTF8 -sEXPORTED_FUNCTIONS=_cast,_call,_next_remote_object_key,_main -sEXPORT_ES6=1 -sUSE_ZLIB=1 -O3 -pthread -sFETCH --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/atomvm.pre.js)
+target_link_options(AtomVM PRIVATE -sEXPORTED_RUNTIME_METHODS=ccall,cwrap,stringToNewUTF8 -sEXPORTED_FUNCTIONS=_malloc,_cast,_call,_next_remote_object_key,_next_tracked_object_key,_main -sEXPORT_ES6=1 -sUSE_ZLIB=1 -O3 -pthread -sFETCH --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/atomvm.pre.js)
 set(CMAKE_EXECUTABLE_SUFFIX ".mjs")
+
+# Ensure AtomVM is rebuilt when atomvm.pre.js changes
+set_target_properties(AtomVM PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/atomvm.pre.js)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_link_options(AtomVM PRIVATE -sASSERTIONS=2 -sSAFE_HEAP -sSTACK_OVERFLOW_CHECK)

--- a/src/platforms/emscripten/src/CMakeLists.txt
+++ b/src/platforms/emscripten/src/CMakeLists.txt
@@ -26,9 +26,9 @@ target_compile_features(AtomVM PUBLIC c_std_11)
 
 add_subdirectory(../../../libAtomVM libAtomVM)
 target_link_libraries(AtomVM PUBLIC libAtomVM)
-target_compile_options(libAtomVM PUBLIC -O3 -fno-exceptions -fno-rtti -pthread -sINLINING_LIMIT -sUSE_ZLIB=1)
+target_compile_options(libAtomVM PUBLIC -O3 -fno-omit-frame-pointer -fno-exceptions -fno-rtti -pthread -sINLINING_LIMIT -sUSE_ZLIB=1)
 target_compile_definitions(libAtomVM PRIVATE WITH_ZLIB)
-target_link_options(AtomVM PRIVATE -sEXPORTED_RUNTIME_METHODS=ccall,cwrap,stringToNewUTF8 -sEXPORTED_FUNCTIONS=_malloc,_cast,_call,_next_remote_object_key,_next_tracked_object_key,_main -sEXPORT_ES6=1 -sUSE_ZLIB=1 -O3 -pthread -sFETCH --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/atomvm.pre.js)
+target_link_options(AtomVM PRIVATE -sEXPORTED_RUNTIME_METHODS=ccall,cwrap,stringToNewUTF8 -sEXPORTED_FUNCTIONS=_malloc,_cast,_call,_next_tracked_object_key,_main -sEXPORT_ES6=1 -sUSE_ZLIB=1 -O3 -pthread -sFETCH --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/atomvm.pre.js)
 set(CMAKE_EXECUTABLE_SUFFIX ".mjs")
 
 # Ensure AtomVM is rebuilt when atomvm.pre.js changes

--- a/src/platforms/emscripten/src/atomvm.pre.js
+++ b/src/platforms/emscripten/src/atomvm.pre.js
@@ -44,21 +44,33 @@ Module["onGetTrackedObjects"] = (keys) => {
   return keys.map(getRemoteObject);
 };
 Module["onRunTrackedJs"] = (scriptString, isDebug) => {
-  const indirectEval = eval;
-  const result = indirectEval(scriptString);
-  if (isDebug) {
-    if (!Array.isArray(result) && result !== undefined) {
-      throw new Error(
-        "Script passed to onRunTrackedJs() returned invalid value, accepted values are arrays and undefined",
-      );
-    }
+  const trackValue = (value) => {
+    const key = Module["nextRemoteObjectKey"]();
+    Module["remoteObjectsMap"].set(key, value);
+    return key;
+  };
+
+  let result;
+  try {
+    const indirectEval = eval;
+    result = indirectEval(scriptString);
+  } catch (_e) {
+    return null;
+  }
+  isDebug && ensureValidResult(result);
+  return result?.map(trackValue) ?? [];
+};
+function ensureValidResult(result) {
+  const isIndex = (k) => typeof k === "number";
+
+  if (result === null) {
+    return;
+  }
+  if (Array.isArray(result) && keys.every(isIndex)) {
+    return;
   }
 
-  return (
-    result?.map((value) => {
-      const key = Module["nextRemoteObjectKey"]();
-      Module["remoteObjectsMap"].set(key, value);
-      return key;
-    }) ?? []
-  );
-};
+  const message =
+    "Evaluated script returned invalid value. Expected number array or null";
+  throw new Error(message);
+}

--- a/src/platforms/emscripten/src/atomvm.pre.js
+++ b/src/platforms/emscripten/src/atomvm.pre.js
@@ -30,7 +30,10 @@ Module["call"] = async function (name, message) {
   return promiseMap.get(promiseId).promise;
 };
 Module["nextRemoteObjectKey"] = function () {
-  ccall("next_remote_object_key", "integer", [], []);
+  return ccall("next_remote_object_key", "integer", [], []);
+};
+Module["nextTrackedObjectKey"] = function () {
+  return ccall("next_tracked_object_key", "integer", [], []);
 };
 Module["remoteObjectsMap"] = new Map();
 Module["onRemoteObjectDelete"] = (_key) => {};

--- a/src/platforms/emscripten/src/atomvm.pre.js
+++ b/src/platforms/emscripten/src/atomvm.pre.js
@@ -29,24 +29,21 @@ Module["call"] = async function (name, message) {
   );
   return promiseMap.get(promiseId).promise;
 };
-Module["nextRemoteObjectKey"] = function () {
-  return ccall("next_remote_object_key", "integer", [], []);
-};
 Module["nextTrackedObjectKey"] = function () {
   return ccall("next_tracked_object_key", "integer", [], []);
 };
-Module["remoteObjectsMap"] = new Map();
-Module["onRemoteObjectDelete"] = (key) => {
-  Module["remoteObjectsMap"].delete(key);
+Module["trackedObjectsMap"] = new Map();
+Module["onTrackedObjectDelete"] = (key) => {
+  Module["trackedObjectsMap"].delete(key);
 };
 Module["onGetTrackedObjects"] = (keys) => {
-  const getRemoteObject = (key) => Module["remoteObjectsMap"].get(key);
-  return keys.map(getRemoteObject);
+  const getTrackedObject = (key) => Module["trackedObjectsMap"].get(key);
+  return keys.map(getTrackedObject);
 };
 Module["onRunTrackedJs"] = (scriptString, isDebug) => {
   const trackValue = (value) => {
-    const key = Module["nextRemoteObjectKey"]();
-    Module["remoteObjectsMap"].set(key, value);
+    const key = Module["nextTrackedObjectKey"]();
+    Module["trackedObjectsMap"].set(key, value);
     return key;
   };
 

--- a/src/platforms/emscripten/src/atomvm.pre.js
+++ b/src/platforms/emscripten/src/atomvm.pre.js
@@ -36,7 +36,13 @@ Module["nextTrackedObjectKey"] = function () {
   return ccall("next_tracked_object_key", "integer", [], []);
 };
 Module["remoteObjectsMap"] = new Map();
-Module["onRemoteObjectDelete"] = (_key) => {};
+Module["onRemoteObjectDelete"] = (key) => {
+  Module["remoteObjectsMap"].delete(key);
+};
+Module["onGetTrackedObjects"] = (keys) => {
+  const getRemoteObject = (key) => Module["remoteObjectsMap"].get(key);
+  return keys.map(getRemoteObject);
+};
 Module["onRunTrackedJs"] = (scriptString, isDebug) => {
   const indirectEval = eval;
   const result = indirectEval(scriptString);

--- a/src/platforms/emscripten/src/atomvm.pre.js
+++ b/src/platforms/emscripten/src/atomvm.pre.js
@@ -37,3 +37,22 @@ Module["nextTrackedObjectKey"] = function () {
 };
 Module["remoteObjectsMap"] = new Map();
 Module["onRemoteObjectDelete"] = (_key) => {};
+Module["onRunTrackedJs"] = (scriptString, isDebug) => {
+  const indirectEval = eval;
+  const result = indirectEval(scriptString);
+  if (isDebug) {
+    if (!Array.isArray(result) && result !== undefined) {
+      throw new Error(
+        "Script passed to onRunTrackedJs() returned invalid value, accepted values are arrays and undefined",
+      );
+    }
+  }
+
+  return (
+    result?.map((value) => {
+      const key = Module["nextRemoteObjectKey"]();
+      Module["remoteObjectsMap"].set(key, value);
+      return key;
+    }) ?? []
+  );
+};

--- a/src/platforms/emscripten/src/lib/emscripten_sys.h
+++ b/src/platforms/emscripten/src/lib/emscripten_sys.h
@@ -108,6 +108,7 @@ struct EmscriptenPlatformData
     pthread_cond_t poll_cond;
     struct ListHead messages;
     atomic_size_t next_remote_object_index;
+    atomic_size_t next_tracked_object_index;
     ErlNifResourceType *promise_resource_type;
     ErlNifResourceType *htmlevent_user_data_resource_type;
     ErlNifResourceType *remote_object_resource_type;
@@ -115,6 +116,7 @@ struct EmscriptenPlatformData
 
 void sys_enqueue_emscripten_cast_message(GlobalContext *glb, const char *target, const char *message);
 size_t sys_get_next_remote_object_key(GlobalContext *glb);
+size_t sys_get_next_tracked_object_key(GlobalContext *glb);
 em_promise_t sys_enqueue_emscripten_call_message(GlobalContext *glb, const char *target, const char *message);
 void sys_enqueue_emscripten_htmlevent_message(GlobalContext *glb, int32_t target_pid, term message, term user_data, HeapFragment *heap);
 void sys_enqueue_emscripten_unregister_htmlevent_message(GlobalContext *glb, struct HTMLEventUserDataResource *rsrc);

--- a/src/platforms/emscripten/src/lib/emscripten_sys.h
+++ b/src/platforms/emscripten/src/lib/emscripten_sys.h
@@ -52,7 +52,7 @@ struct HTMLEventUserDataResource
     term storage[];
 };
 
-struct RemoteObjectResource
+struct TrackedObjectResource
 {
     int32_t key;
 };
@@ -107,15 +107,13 @@ struct EmscriptenPlatformData
     pthread_mutex_t poll_mutex;
     pthread_cond_t poll_cond;
     struct ListHead messages;
-    atomic_size_t next_remote_object_index;
     atomic_size_t next_tracked_object_index;
     ErlNifResourceType *promise_resource_type;
     ErlNifResourceType *htmlevent_user_data_resource_type;
-    ErlNifResourceType *remote_object_resource_type;
+    ErlNifResourceType *tracked_object_resource_type;
 };
 
 void sys_enqueue_emscripten_cast_message(GlobalContext *glb, const char *target, const char *message);
-size_t sys_get_next_remote_object_key(GlobalContext *glb);
 size_t sys_get_next_tracked_object_key(GlobalContext *glb);
 em_promise_t sys_enqueue_emscripten_call_message(GlobalContext *glb, const char *target, const char *message);
 void sys_enqueue_emscripten_htmlevent_message(GlobalContext *glb, int32_t target_pid, term message, term user_data, HeapFragment *heap);

--- a/src/platforms/emscripten/src/lib/platform_defaultatoms.c
+++ b/src/platforms/emscripten/src/lib/platform_defaultatoms.c
@@ -21,12 +21,14 @@
 #include "platform_defaultatoms.h"
 
 static const char *const emscripten_atom = ATOM_STR("\xA", "emscripten");
+static const char *const bad_value = ATOM_STR("\x8", "badvalue");
 
 void platform_defaultatoms_init(GlobalContext *glb)
 {
     int ok = 1;
 
     ok &= globalcontext_insert_atom(glb, emscripten_atom) == EMSCRIPTEN_ATOM_INDEX;
+    ok &= globalcontext_insert_atom(glb, bad_value) == BADVALUE_ATOM_INDEX;
 
     if (!ok) {
         AVM_ABORT();

--- a/src/platforms/emscripten/src/lib/platform_defaultatoms.h
+++ b/src/platforms/emscripten/src/lib/platform_defaultatoms.h
@@ -24,7 +24,9 @@
 #include "defaultatoms.h"
 
 #define EMSCRIPTEN_ATOM_INDEX (PLATFORM_ATOMS_BASE_INDEX + 0)
+#define BADVALUE_ATOM_INDEX (PLATFORM_ATOMS_BASE_INDEX + 1)
 
 #define EMSCRIPTEN_ATOM term_from_atom_index(EMSCRIPTEN_ATOM_INDEX)
+#define BADVALUE_ATOM term_from_atom_index(BADVALUE_ATOM_INDEX)
 
 #endif

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -123,27 +123,10 @@ static term nif_emscripten_run_script(Context *ctx, int argc, term argv[])
     return ret;
 }
 
-static char *annotate_js_fn_with_storage(atomic_size_t key, char *js_fn)
-{
-    const char *pattern = "try { Module['remoteObjectsMap'].set(%d, (%.*s)(Module, %d)) } catch(e) { console.error(e) }";
-    size_t injected_size = strlen(pattern) - 2 - 4 - 2; // don't count patterns
-    size_t number_size = 2 * snprintf(NULL, 0, "%ld", key);
-    size_t js_fn_size = strlen(js_fn);
-    size_t total_size = injected_size + number_size + js_fn_size + 1;
-    char *buffer = malloc(total_size);
-    if (IS_NULL_PTR(buffer)) {
-        return NULL;
-    }
-
-    snprintf(buffer, total_size, pattern, key, js_fn_size, js_fn, key);
-
-    return buffer;
-}
-
-static term term_remote_object_from_key(Context *ctx, atomic_size_t key)
+static term term_tracked_object_from_key(Context *ctx, atomic_size_t key)
 {
     struct EmscriptenPlatformData *platform = ctx->global->platform_data;
-    struct RemoteObjectResource *rsrc_obj = enif_alloc_resource(platform->remote_object_resource_type, sizeof(struct RemoteObjectResource));
+    struct TrackedObjectResource *rsrc_obj = enif_alloc_resource(platform->tracked_object_resource_type, sizeof(struct TrackedObjectResource));
     if (IS_NULL_PTR(rsrc_obj)) {
         return term_invalid_term();
     }
@@ -151,132 +134,6 @@ static term term_remote_object_from_key(Context *ctx, atomic_size_t key)
     term obj = enif_make_resource(erl_nif_env_from_context(ctx), rsrc_obj);
     enif_release_resource(rsrc_obj);
     return obj;
-}
-
-static term nif_emscripten_run_remote_object_script_fn(Context *ctx, int argc, term argv[])
-{
-    UNUSED(argc);
-
-    int ok;
-    char *str = interop_term_to_string(argv[0], &ok);
-    if (UNLIKELY(!ok)) {
-        RAISE_ERROR(BADARG_ATOM);
-    }
-    struct EmscriptenPlatformData *platform = ctx->global->platform_data;
-    atomic_size_t key = platform->next_remote_object_index++;
-    char *script = annotate_js_fn_with_storage(key, str);
-    free(str);
-    if (IS_NULL_PTR(script)) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-    }
-
-    bool main_thread = false;
-    bool async = false;
-    if (argc == 2) {
-        term main_thread_t = interop_kv_get_value_default(argv[1], ATOM_STR("\xB", "main_thread"), FALSE_ATOM, ctx->global);
-        main_thread = main_thread_t == TRUE_ATOM;
-
-        if (!main_thread) {
-            RAISE_ERROR(BADARG_ATOM);
-        }
-
-        term async_t = interop_kv_get_value_default(argv[1], ATOM_STR("\x5", "async"), FALSE_ATOM, ctx->global);
-        async = async_t == TRUE_ATOM;
-        if (!main_thread && async) {
-            RAISE_ERROR(BADARG_ATOM);
-        }
-    }
-
-    if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-    }
-    term obj = term_remote_object_from_key(ctx, key);
-    if (UNLIKELY(term_is_invalid_term(obj))) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-    }
-    term ret = term_alloc_tuple(2, &ctx->heap);
-    term_put_tuple_element(ret, 0, OK_ATOM);
-    term_put_tuple_element(ret, 1, obj);
-
-    if (main_thread) {
-        if (async) {
-            // script will be freed as it's passed as satellite
-            emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VIIIII, do_run_script, script, ctx->global, script, false, 0, ret);
-        } else {
-            // Trap caller waiting for completion
-            context_update_flags(ctx, ~NoFlags, Trap);
-            // script will be freed as it's passed as satellite
-            emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VIIIII, do_run_script, script, ctx->global, script, true, ctx->process_id, ret);
-            ret = term_invalid_term();
-        }
-    } else {
-        emscripten_run_script(script);
-        free(script);
-    }
-
-    return ret;
-}
-
-static void do_get_remote_object(Context *ctx, atomic_size_t key, int sync_caller_pid)
-{
-    term reply = term_invalid_term();
-    char *serialized = (char *) EM_ASM_PTR({
-        const remoteObject = Module['remoteObjectsMap'].get($0);
-        if(remoteObject === undefined) {
-            return stringToNewUTF8("");
-        }
-        return stringToNewUTF8(remoteObject); }, key);
-    size_t size = strlen(serialized);
-    if (UNLIKELY(memory_ensure_free_opt(ctx, term_binary_heap_size(size) + TUPLE_SIZE(2), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-        free(serialized);
-        reply = ERROR_ATOM;
-        goto send_signal;
-    }
-
-    reply = term_alloc_tuple(2, &ctx->heap);
-    if (UNLIKELY(size == 0)) {
-        free(serialized);
-        term_put_tuple_element(reply, 0, ERROR_ATOM);
-        term_put_tuple_element(reply, 1, BADKEY_ATOM);
-        goto send_signal;
-    }
-
-    term serialized_term = term_from_literal_binary(serialized, size, &ctx->heap, ctx->global);
-    free(serialized);
-    term_put_tuple_element(reply, 0, OK_ATOM);
-    term_put_tuple_element(reply, 1, serialized_term);
-    Context *target = NULL;
-send_signal:
-    target = globalcontext_get_process_lock(ctx->global, sync_caller_pid);
-    if (target) {
-        mailbox_send_term_signal(target, TrapAnswerSignal, reply);
-        globalcontext_get_process_unlock(ctx->global, target);
-    } // else: sender died
-}
-
-static term nif_emscripten_from_remote_object(Context *ctx, int argc, term argv[])
-{
-    UNUSED(argc);
-
-    struct EmscriptenPlatformData *platform = ctx->global->platform_data;
-
-    ErlNifEnv *env = erl_nif_env_from_context(ctx);
-    void *obj;
-    if (UNLIKELY(!enif_get_resource(env, argv[0], platform->remote_object_resource_type, &obj))) {
-        RAISE_ERROR(BADARG_ATOM);
-    }
-    struct RemoteObjectResource *remote_object_rsrc = (struct RemoteObjectResource *) obj;
-
-    if (argv[1] == KEY_ATOM) {
-        return term_from_int64(remote_object_rsrc->key);
-    } else if (argv[1] == VALUE_ATOM) {
-        // Trap caller waiting for completion
-        context_update_flags(ctx, ~NoFlags, Trap);
-        emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VIII, do_get_remote_object, NULL, ctx, remote_object_rsrc->key, ctx->process_id);
-        return term_invalid_term();
-    } else {
-        RAISE_ERROR(BADARG_ATOM);
-    }
 }
 
 // clang-format off
@@ -328,10 +185,10 @@ static void do_run_script_tracked(const char *script, int32_t sync_caller_pid, G
         }
 
         for (long i = keys_n - 1; i >= 0; --i) {
-            term remote_object = term_remote_object_from_key(target_ctx, keys[i]);
+            term tracked_object = term_tracked_object_from_key(target_ctx, keys[i]);
             // we can't easily recover from OOM here
-            assert(!term_is_invalid_term(remote_object));
-            refs = term_list_prepend(remote_object, refs, &target_ctx->heap);
+            assert(!term_is_invalid_term(tracked_object));
+            refs = term_list_prepend(tracked_object, refs, &target_ctx->heap);
         }
         term_put_tuple_element(result, 0, OK_ATOM);
         term_put_tuple_element(result, 1, refs);
@@ -519,12 +376,12 @@ static term nif_emscripten_get_tracked(Context *ctx, int argc, term argv[])
     for (size_t i = 0; i < n; ++i) {
         term ref = term_get_list_head(refs);
         void *obj;
-        if (UNLIKELY(!enif_get_resource(env, ref, platform->remote_object_resource_type, &obj))) {
+        if (UNLIKELY(!enif_get_resource(env, ref, platform->tracked_object_resource_type, &obj))) {
             free(ref_keys);
             RAISE_ERROR(BADARG_ATOM);
         }
-        struct RemoteObjectResource *remote_object_rsrc = (struct RemoteObjectResource *) obj;
-        ref_keys[i] = remote_object_rsrc->key;
+        struct TrackedObjectResource *tracked_object_rsrc = (struct TrackedObjectResource *) obj;
+        ref_keys[i] = tracked_object_rsrc->key;
         refs = term_get_list_tail(refs);
     }
 
@@ -594,14 +451,6 @@ static const struct Nif atomvm_random_nif = {
 static const struct Nif emscripten_run_script_nif = {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_emscripten_run_script
-};
-static const struct Nif emscripten_run_remote_object_script_fn = {
-    .base.type = NIFFunctionType,
-    .nif_ptr = nif_emscripten_run_remote_object_script_fn
-};
-static const struct Nif emscripten_from_remote_object = {
-    .base.type = NIFFunctionType,
-    .nif_ptr = nif_emscripten_from_remote_object,
 };
 static const struct Nif emscripten_run_script_tracked = {
     .base.type = NIFFunctionType,
@@ -1224,15 +1073,6 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
     }
     if (strcmp("run_script/2", nifname) == 0) {
         return &emscripten_run_script_nif;
-    }
-    if (strcmp("run_remote_object_fn_script/1", nifname) == 0) {
-        return &emscripten_run_remote_object_script_fn;
-    }
-    if (strcmp("run_remote_object_fn_script/2", nifname) == 0) {
-        return &emscripten_run_remote_object_script_fn;
-    }
-    if (strcmp("from_remote_object/2", nifname) == 0) {
-        return &emscripten_from_remote_object;
     }
     if (strcmp("run_script_tracked/1", nifname) == 0) {
         return &emscripten_run_script_tracked;

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -296,6 +296,7 @@ EM_JS(uint32_t *, js_tracked_eval, (const char *code, uint32_t *size, bool debug
     HEAPU32.set(keys, ptr / HEAPU32.BYTES_PER_ELEMENT);
     return ptr;
 });
+// clang-format on
 
 static void do_run_script_tracked(const char *script, int32_t sync_caller_pid, GlobalContext *global)
 {
@@ -318,11 +319,11 @@ static void do_run_script_tracked(const char *script, int32_t sync_caller_pid, G
         remote_objects = malloc(keys_n * sizeof(term));
         if (IS_NULL_PTR(remote_objects)) {
             result = OUT_OF_MEMORY_ATOM;
-            goto cleanup;
+            goto send_result;
         }
         if (UNLIKELY(memory_ensure_free_opt(target_ctx, TUPLE_SIZE(2) + LIST_SIZE(keys_n, 1), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             result = OUT_OF_MEMORY_ATOM;
-            goto cleanup;
+            goto send_result;
         }
 
         for (size_t i = 0; i < keys_n; ++i) {
@@ -340,10 +341,8 @@ static void do_run_script_tracked(const char *script, int32_t sync_caller_pid, G
         term_put_tuple_element(result, 0, OK_ATOM);
         term_put_tuple_element(result, 1, refs);
 
-    cleanup:
+    send_result:
         free(remote_objects);
-        printf("%d: %ld\n", keys_n, result);
-        term_display(stdout, result, target_ctx);
         mailbox_send_term_signal(target_ctx, TrapAnswerSignal, result);
         globalcontext_get_process_unlock(global, target_ctx);
     } // else: sender died
@@ -352,7 +351,6 @@ static void do_run_script_tracked(const char *script, int32_t sync_caller_pid, G
 static term nif_emscripten_run_script_tracked(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc);
-    UNUSED(argv);
     term script_term = argv[0];
 
     int ok;
@@ -367,23 +365,83 @@ static term nif_emscripten_run_script_tracked(Context *ctx, int argc, term argv[
     return term_invalid_term();
 }
 
+static void do_get_tracked_object(int32_t *ref_keys, size_t n, int32_t sync_caller_pid, GlobalContext *global)
+{
+    Context *target_ctx = globalcontext_get_process_lock(global, sync_caller_pid);
+    if (target_ctx) {
+        term result = term_invalid_term();
+        if (UNLIKELY(memory_ensure_free_opt(target_ctx, TUPLE_SIZE(3), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+            result = OUT_OF_MEMORY_ATOM;
+            goto send_result;
+        }
+        result = term_alloc_tuple(3, &target_ctx->heap);
+        term_put_tuple_element(result, 0, OK_ATOM);
+        term_put_tuple_element(result, 1, term_nil());
+        term_put_tuple_element(result, 2, term_nil());
+    send_result:
+        mailbox_send_term_signal(target_ctx, TrapAnswerSignal, result);
+        globalcontext_get_process_unlock(global, target_ctx);
+    } // else: sender died
+}
+
 static term nif_emscripten_get_tracked(Context *ctx, int argc, term argv[])
 {
-    UNUSED(ctx);
     UNUSED(argc);
-    UNUSED(argv);
+    term refs = argv[0];
+    term type = argv[1];
+    struct EmscriptenPlatformData *platform = ctx->global->platform_data;
+    ErlNifEnv *env = erl_nif_env_from_context(ctx);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2) + CONS_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    VALIDATE_VALUE(refs, term_is_list);
+    if (UNLIKELY(type != KEY_ATOM && type != VALUE_ATOM)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    int proper;
+    size_t n = term_list_length(refs, &proper);
+    if (UNLIKELY(!proper)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    if (n == 0) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
+    int32_t *ref_keys = malloc(n * sizeof(int32_t));
+    if (IS_NULL_PTR(ref_keys)) {
         RAISE_ERROR(OUT_OF_MEMORY_ATOM);
     }
 
-    term values = term_nil();
-    values = term_list_prepend(term_from_int(1), values, &ctx->heap);
+    for (size_t i = 0; i < n; ++i) {
+        term ref = term_get_list_head(refs);
+        void *obj;
+        if (UNLIKELY(!enif_get_resource(env, ref, platform->remote_object_resource_type, &obj))) {
+            free(ref_keys);
+            RAISE_ERROR(BADARG_ATOM);
+        }
+        struct RemoteObjectResource *remote_object_rsrc = (struct RemoteObjectResource *) obj;
+        ref_keys[i] = remote_object_rsrc->key;
+        refs = term_get_list_tail(refs);
+    }
 
-    term result_tuple = term_alloc_tuple(2, &ctx->heap);
-    term_put_tuple_element(result_tuple, 0, OK_ATOM);
-    term_put_tuple_element(result_tuple, 1, values);
-    return result_tuple;
+    if (type == KEY_ATOM) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, LIST_SIZE(n, 1) + TUPLE_SIZE(3), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        }
+
+        term keys = term_nil();
+        for (long i = n - 1; i >= 0; --i) {
+            keys = term_list_prepend(term_from_int32(ref_keys[i]), keys, &ctx->heap);
+        }
+        term tuple = term_alloc_tuple(2, &ctx->heap);
+        term_put_tuple_element(tuple, 0, OK_ATOM);
+        term_put_tuple_element(tuple, 1, keys);
+        return tuple;
+    }
+    assert(type == VALUE_ATOM);
+    // Trap caller waiting for completion
+    context_update_flags(ctx, ~NoFlags, Trap);
+    emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VIIII, do_get_tracked_object, NULL, ref_keys, n, ctx->process_id, ctx->global);
+    return term_invalid_term();
 }
 
 static term nif_emscripten_promise_resolve_reject(Context *ctx, int argc, term argv[], em_promise_result_t result)

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -278,20 +278,93 @@ static term nif_emscripten_from_remote_object(Context *ctx, int argc, term argv[
     }
 }
 
+// clang-format off
+EM_JS(uint32_t *, js_tracked_eval, (const char *code, uint32_t *size, bool debug), {
+    const keys = Module['onRunTrackedJs'](UTF8ToString(code), debug);
+    if (debug) {
+        if (!Array.isArray(keys)) {
+            throw new Error("onRunTrackedJs() returned non-array");
+        }
+        const isIndex = k => typeof(k) === "number";
+        if (!keys.every(isIndex)) {
+            throw new Error("onRunTrackedJs() non-numeric array");
+        }
+    }
+    // emscripten's malloc impl crashes wasm module on failed alloc so no checking for that
+    const ptr = Module['_malloc'](keys.length * HEAPU32.BYTES_PER_ELEMENT);
+    HEAPU32.set([keys.length], size / HEAPU32.BYTES_PER_ELEMENT);
+    HEAPU32.set(keys, ptr / HEAPU32.BYTES_PER_ELEMENT);
+    return ptr;
+});
+
+static void do_run_script_tracked(const char *script, int32_t sync_caller_pid, GlobalContext *global)
+{
+#ifdef NDEBUG
+    bool debug = false;
+#else
+    bool debug = true;
+#endif
+    uint32_t keys_n;
+    uint32_t *keys = js_tracked_eval(script, &keys_n, debug);
+    Context *target_ctx = globalcontext_get_process_lock(global, sync_caller_pid);
+    if (target_ctx) {
+        term result = term_invalid_term();
+        term refs = term_nil();
+        term *remote_objects = NULL;
+        if (keys_n == 0) {
+            goto create_tuple;
+        }
+
+        remote_objects = malloc(keys_n * sizeof(term));
+        if (IS_NULL_PTR(remote_objects)) {
+            result = OUT_OF_MEMORY_ATOM;
+            goto cleanup;
+        }
+        if (UNLIKELY(memory_ensure_free_opt(target_ctx, TUPLE_SIZE(2) + LIST_SIZE(keys_n, 1), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+            result = OUT_OF_MEMORY_ATOM;
+            goto cleanup;
+        }
+
+        for (size_t i = 0; i < keys_n; ++i) {
+            remote_objects[i] = term_remote_object_from_key(target_ctx, keys[i]);
+            // we can't easily recover from OOM here
+            assert(!term_is_invalid_term(remote_objects[i]));
+        }
+
+        for (long i = keys_n - 1; i >= 0; --i) {
+            refs = term_list_prepend(remote_objects[i], refs, &target_ctx->heap);
+        }
+
+    create_tuple:
+        result = term_alloc_tuple(2, &target_ctx->heap);
+        term_put_tuple_element(result, 0, OK_ATOM);
+        term_put_tuple_element(result, 1, refs);
+
+    cleanup:
+        free(remote_objects);
+        printf("%d: %ld\n", keys_n, result);
+        term_display(stdout, result, target_ctx);
+        mailbox_send_term_signal(target_ctx, TrapAnswerSignal, result);
+        globalcontext_get_process_unlock(global, target_ctx);
+    } // else: sender died
+}
+
 static term nif_emscripten_run_script_tracked(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc);
     UNUSED(argv);
-    if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2) + CONS_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
-    }
-    term values = term_nil();
-    values = term_list_prepend(term_from_int(1), values, &ctx->heap);
+    term script_term = argv[0];
 
-    term result_tuple = term_alloc_tuple(2, &ctx->heap);
-    term_put_tuple_element(result_tuple, 0, OK_ATOM);
-    term_put_tuple_element(result_tuple, 1, values);
-    return result_tuple;
+    int ok;
+    char *script = interop_term_to_string(script_term, &ok);
+    if (UNLIKELY(!ok)) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+    // Trap caller waiting for completion
+    context_update_flags(ctx, ~NoFlags, Trap);
+    // script will be freed as it's passed as satellite
+    emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VIII, do_run_script_tracked, script, script, ctx->process_id, ctx->global);
+    return term_invalid_term();
 }
 
 static term nif_emscripten_get_tracked(Context *ctx, int argc, term argv[])

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -27,6 +27,7 @@
 #include <nifs.h>
 #include <stdatomic.h>
 #include <stdint.h>
+#include <string.h>
 #include <term.h>
 #include <term_typedef.h>
 
@@ -290,7 +291,7 @@ EM_JS(uint32_t *, js_tracked_eval, (const char *code, uint32_t *size, bool debug
             throw new Error("onRunTrackedJs() non-numeric array");
         }
     }
-    // emscripten's malloc impl crashes wasm module on failed alloc so no checking for that
+    // emscripten's malloc impl crashes wasm module on failed alloc so no point checking for that
     const ptr = Module['_malloc'](keys.length * HEAPU32.BYTES_PER_ELEMENT);
     HEAPU32.set([keys.length], size / HEAPU32.BYTES_PER_ELEMENT);
     HEAPU32.set(keys, ptr / HEAPU32.BYTES_PER_ELEMENT);
@@ -365,19 +366,128 @@ static term nif_emscripten_run_script_tracked(Context *ctx, int argc, term argv[
     return term_invalid_term();
 }
 
-static void do_get_tracked_object(int32_t *ref_keys, size_t n, int32_t sync_caller_pid, GlobalContext *global)
+// clang-format off
+EM_JS(char *, js_get_tracked_object, (uint32_t *keys_ptr, uint32_t keys_n, uint32_t **sizes, uint8_t **statuses, uint32_t *objects_n, uint32_t *strings_n, uint32_t *all_byte_size), {
+    const OK = 0;
+    const BAD_KEY = 1;
+    const NOT_STRING = 2;
+
+    const keysOffset = keys_ptr / HEAPU32.BYTES_PER_ELEMENT;
+    const keys = [...HEAPU32.subarray(keysOffset, keysOffset + keys_n)];
+
+    const objects = Module['onGetTrackedObjects'](keys);
+        if (!Array.isArray(objects)) {
+        return 0;
+    }
+    const n = objects.length;
+
+    if (n === 0) {
+        return 0;
+    }
+
+    const sizesPtr = Module['_malloc'](n * HEAPU32.BYTES_PER_ELEMENT);
+    const statusPtr = Module['_malloc'](n * HEAPU8.BYTES_PER_ELEMENT);
+    let allByteSize = 0;
+    let stringsN = 0;
+
+    for (let i = 0; i < n; ++i) {
+        let status = OK;
+        let byteSize = 0;
+        const object = objects[i];
+                if (object === undefined) {
+            status = BAD_KEY;
+        } else if (typeof object !== "string") {
+            status = NOT_STRING;
+        } else {
+            byteSize = lengthBytesUTF8(object);
+            stringsN += 1;
+        }
+        HEAPU8[statusPtr / HEAPU8.BYTES_PER_ELEMENT + i] = status;
+        HEAPU32[sizesPtr / HEAPU32.BYTES_PER_ELEMENT + i] = byteSize;
+        allByteSize += byteSize;
+    }
+
+    const stringsPtr = Module['_malloc'](allByteSize * HEAPU8.BYTES_PER_ELEMENT);
+    let currentStringsPtr = stringsPtr;
+    for (let i = 0; i < n; ++i) {
+        const status = HEAPU8[statusPtr / HEAPU8.BYTES_PER_ELEMENT + i];
+        if (status !== OK) {
+            continue;
+        }
+        const string = objects[i];
+        const size = HEAPU32[sizesPtr / HEAPU32.BYTES_PER_ELEMENT + i];
+        // stringToUTF8 includes null byte which we don't need
+        stringToUTF8(string, currentStringsPtr, size+1);
+        currentStringsPtr += size;
+    }
+
+    HEAPU32[statuses / HEAPU32.BYTES_PER_ELEMENT] = statusPtr;
+    HEAPU32[sizes / HEAPU32.BYTES_PER_ELEMENT] = sizesPtr;
+    HEAPU32[objects_n / HEAPU32.BYTES_PER_ELEMENT] = n;
+    HEAPU32[strings_n / HEAPU32.BYTES_PER_ELEMENT] = stringsN;
+    HEAPU32[all_byte_size / HEAPU32.BYTES_PER_ELEMENT] = allByteSize;
+
+    return stringsPtr;
+});
+// clang-format on
+
+typedef enum
 {
+    TO_OK = 0,
+    TO_BAD_KEY = 1,
+    TO_NOT_STRING = 2,
+} TrackedObjectStatus;
+
+static void do_get_tracked_object(uint32_t *ref_keys, size_t keys_n, int32_t sync_caller_pid, GlobalContext *global)
+{
+    uint32_t objects_n;
+    uint32_t strings_n;
+    uint32_t all_byte_size;
+    uint32_t *sizes;
+    uint8_t *statuses;
+
+    const char *strings = js_get_tracked_object(ref_keys, keys_n, &sizes, &statuses, &objects_n, &strings_n, &all_byte_size);
+    assert(strings_n <= objects_n);
     Context *target_ctx = globalcontext_get_process_lock(global, sync_caller_pid);
     if (target_ctx) {
         term result = term_invalid_term();
-        if (UNLIKELY(memory_ensure_free_opt(target_ctx, TUPLE_SIZE(3), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        if (IS_NULL_PTR(strings)) {
+            result = BADVALUE_ATOM;
+            goto send_result;
+        }
+        size_t size = LIST_SIZE(objects_n, TUPLE_SIZE(2)) + LIST_SIZE(strings_n, BINARY_HEADER_SIZE) + term_binary_data_size_in_terms(all_byte_size);
+        if (UNLIKELY(memory_ensure_free_opt(target_ctx, size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             result = OUT_OF_MEMORY_ATOM;
             goto send_result;
         }
-        result = term_alloc_tuple(3, &target_ctx->heap);
-        term_put_tuple_element(result, 0, OK_ATOM);
-        term_put_tuple_element(result, 1, term_nil());
-        term_put_tuple_element(result, 2, term_nil());
+
+        // move pointer to one byte past buffer
+        const char *current_string = strings + all_byte_size;
+        result = term_nil();
+        for (long i = objects_n - 1; i >= 0; --i) {
+            TrackedObjectStatus status = statuses[i];
+
+            term tuple = term_alloc_tuple(2, &target_ctx->heap);
+            if (status == TO_OK) {
+                size_t size = sizes[i];
+                current_string -= size;
+
+                term binary = term_create_uninitialized_binary(size, &target_ctx->heap, global);
+                char *data = (char *) term_binary_data(binary);
+                memcpy(data, current_string, size);
+
+                term_put_tuple_element(tuple, 0, OK_ATOM);
+                term_put_tuple_element(tuple, 1, binary);
+            } else if (status == TO_NOT_STRING) {
+                term_put_tuple_element(tuple, 0, ERROR_ATOM);
+                term_put_tuple_element(tuple, 1, BADVALUE_ATOM);
+            } else /* TO_BAD_KEY */ {
+                term_put_tuple_element(tuple, 0, ERROR_ATOM);
+                term_put_tuple_element(tuple, 1, BADKEY_ATOM);
+            }
+            result = term_list_prepend(tuple, result, &target_ctx->heap);
+        }
+
     send_result:
         mailbox_send_term_signal(target_ctx, TrapAnswerSignal, result);
         globalcontext_get_process_unlock(global, target_ctx);
@@ -424,7 +534,7 @@ static term nif_emscripten_get_tracked(Context *ctx, int argc, term argv[])
     }
 
     if (type == KEY_ATOM) {
-        if (UNLIKELY(memory_ensure_free_opt(ctx, LIST_SIZE(n, 1) + TUPLE_SIZE(3), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, LIST_SIZE(n, 1), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
 
@@ -432,10 +542,7 @@ static term nif_emscripten_get_tracked(Context *ctx, int argc, term argv[])
         for (long i = n - 1; i >= 0; --i) {
             keys = term_list_prepend(term_from_int32(ref_keys[i]), keys, &ctx->heap);
         }
-        term tuple = term_alloc_tuple(2, &ctx->heap);
-        term_put_tuple_element(tuple, 0, OK_ATOM);
-        term_put_tuple_element(tuple, 1, keys);
-        return tuple;
+        return keys;
     }
     assert(type == VALUE_ATOM);
     // Trap caller waiting for completion

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -282,18 +282,14 @@ static term nif_emscripten_from_remote_object(Context *ctx, int argc, term argv[
 // clang-format off
 EM_JS(uint32_t *, js_tracked_eval, (const char *code, uint32_t *size, bool debug), {
     const keys = Module['onRunTrackedJs'](UTF8ToString(code), debug);
-    if (debug) {
-        if (!Array.isArray(keys)) {
-            throw new Error("onRunTrackedJs() returned non-array");
-        }
-        const isIndex = k => typeof(k) === "number";
-        if (!keys.every(isIndex)) {
-            throw new Error("onRunTrackedJs() non-numeric array");
-        }
+    const error = keys === null;
+    if (error) {
+        HEAPU32[size / HEAPU32.BYTES_PER_ELEMENT] = 0;
+        return 0;
     }
-    // emscripten's malloc impl crashes wasm module on failed alloc so no point checking for that
+
     const ptr = Module['_malloc'](keys.length * HEAPU32.BYTES_PER_ELEMENT);
-    HEAPU32.set([keys.length], size / HEAPU32.BYTES_PER_ELEMENT);
+    HEAPU32[size / HEAPU32.BYTES_PER_ELEMENT] = keys.length;
     HEAPU32.set(keys, ptr / HEAPU32.BYTES_PER_ELEMENT);
     return ptr;
 });
@@ -312,38 +308,36 @@ static void do_run_script_tracked(const char *script, int32_t sync_caller_pid, G
     if (target_ctx) {
         term result = term_invalid_term();
         term refs = term_nil();
-        term *remote_objects = NULL;
+        if (UNLIKELY(memory_ensure_free_opt(target_ctx, TUPLE_SIZE(2) + LIST_SIZE(keys_n, TERM_BOXED_REFC_BINARY_SIZE), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+            // TODO: how to raise?
+            result = OUT_OF_MEMORY_ATOM;
+            goto send_result;
+        }
+        result = term_alloc_tuple(2, &target_ctx->heap);
+
+        if (IS_NULL_PTR(keys)) {
+            term_put_tuple_element(result, 0, ERROR_ATOM);
+            term_put_tuple_element(result, 1, BADARG_ATOM);
+            goto send_result;
+        }
+
         if (keys_n == 0) {
-            goto create_tuple;
-        }
-
-        remote_objects = malloc(keys_n * sizeof(term));
-        if (IS_NULL_PTR(remote_objects)) {
-            result = OUT_OF_MEMORY_ATOM;
+            term_put_tuple_element(result, 0, OK_ATOM);
+            term_put_tuple_element(result, 1, term_nil());
             goto send_result;
-        }
-        if (UNLIKELY(memory_ensure_free_opt(target_ctx, TUPLE_SIZE(2) + LIST_SIZE(keys_n, 1), MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
-            result = OUT_OF_MEMORY_ATOM;
-            goto send_result;
-        }
-
-        for (size_t i = 0; i < keys_n; ++i) {
-            remote_objects[i] = term_remote_object_from_key(target_ctx, keys[i]);
-            // we can't easily recover from OOM here
-            assert(!term_is_invalid_term(remote_objects[i]));
         }
 
         for (long i = keys_n - 1; i >= 0; --i) {
-            refs = term_list_prepend(remote_objects[i], refs, &target_ctx->heap);
+            term remote_object = term_remote_object_from_key(target_ctx, keys[i]);
+            // we can't easily recover from OOM here
+            assert(!term_is_invalid_term(remote_object));
+            refs = term_list_prepend(remote_object, refs, &target_ctx->heap);
         }
-
-    create_tuple:
-        result = term_alloc_tuple(2, &target_ctx->heap);
         term_put_tuple_element(result, 0, OK_ATOM);
         term_put_tuple_element(result, 1, refs);
 
     send_result:
-        free(remote_objects);
+        free(keys);
         mailbox_send_term_signal(target_ctx, TrapAnswerSignal, result);
         globalcontext_get_process_unlock(global, target_ctx);
     } // else: sender died
@@ -367,7 +361,7 @@ static term nif_emscripten_run_script_tracked(Context *ctx, int argc, term argv[
 }
 
 // clang-format off
-EM_JS(char *, js_get_tracked_object, (uint32_t *keys_ptr, uint32_t keys_n, uint32_t **sizes, uint8_t **statuses, uint32_t *objects_n, uint32_t *strings_n, uint32_t *all_byte_size), {
+EM_JS(char *, js_get_tracked_objects, (uint32_t *keys_ptr, uint32_t keys_n, uint32_t **sizes, uint8_t **statuses, uint32_t *objects_n, uint32_t *strings_n, uint32_t *all_byte_size), {
     const OK = 0;
     const BAD_KEY = 1;
     const NOT_STRING = 2;
@@ -431,22 +425,20 @@ EM_JS(char *, js_get_tracked_object, (uint32_t *keys_ptr, uint32_t keys_n, uint3
 });
 // clang-format on
 
-typedef enum
+static void do_get_tracked_objects(uint32_t *ref_keys, size_t keys_n, int32_t sync_caller_pid, GlobalContext *global)
 {
-    TO_OK = 0,
-    TO_BAD_KEY = 1,
-    TO_NOT_STRING = 2,
-} TrackedObjectStatus;
+    static const uint8_t OK = 0;
+    static const uint8_t BAD_KEY = 1;
+    static const uint8_t NOT_STRING = 2;
+    UNUSED(BAD_KEY);
 
-static void do_get_tracked_object(uint32_t *ref_keys, size_t keys_n, int32_t sync_caller_pid, GlobalContext *global)
-{
-    uint32_t objects_n;
-    uint32_t strings_n;
-    uint32_t all_byte_size;
-    uint32_t *sizes;
-    uint8_t *statuses;
+    uint32_t objects_n = 0;
+    uint32_t strings_n = 0;
+    uint32_t all_byte_size = 0;
+    uint32_t *sizes = NULL;
+    uint8_t *statuses = NULL;
 
-    const char *strings = js_get_tracked_object(ref_keys, keys_n, &sizes, &statuses, &objects_n, &strings_n, &all_byte_size);
+    char *strings = js_get_tracked_objects(ref_keys, keys_n, &sizes, &statuses, &objects_n, &strings_n, &all_byte_size);
     assert(strings_n <= objects_n);
     Context *target_ctx = globalcontext_get_process_lock(global, sync_caller_pid);
     if (target_ctx) {
@@ -465,10 +457,10 @@ static void do_get_tracked_object(uint32_t *ref_keys, size_t keys_n, int32_t syn
         const char *current_string = strings + all_byte_size;
         result = term_nil();
         for (long i = objects_n - 1; i >= 0; --i) {
-            TrackedObjectStatus status = statuses[i];
+            uint8_t status = statuses[i];
 
             term tuple = term_alloc_tuple(2, &target_ctx->heap);
-            if (status == TO_OK) {
+            if (status == OK) {
                 size_t size = sizes[i];
                 current_string -= size;
 
@@ -478,10 +470,10 @@ static void do_get_tracked_object(uint32_t *ref_keys, size_t keys_n, int32_t syn
 
                 term_put_tuple_element(tuple, 0, OK_ATOM);
                 term_put_tuple_element(tuple, 1, binary);
-            } else if (status == TO_NOT_STRING) {
+            } else if (status == NOT_STRING) {
                 term_put_tuple_element(tuple, 0, ERROR_ATOM);
                 term_put_tuple_element(tuple, 1, BADVALUE_ATOM);
-            } else /* TO_BAD_KEY */ {
+            } else /* BAD_KEY */ {
                 term_put_tuple_element(tuple, 0, ERROR_ATOM);
                 term_put_tuple_element(tuple, 1, BADKEY_ATOM);
             }
@@ -489,6 +481,9 @@ static void do_get_tracked_object(uint32_t *ref_keys, size_t keys_n, int32_t syn
         }
 
     send_result:
+        free(sizes);
+        free(statuses);
+        free(strings);
         mailbox_send_term_signal(target_ctx, TrapAnswerSignal, result);
         globalcontext_get_process_unlock(global, target_ctx);
     } // else: sender died
@@ -547,7 +542,7 @@ static term nif_emscripten_get_tracked(Context *ctx, int argc, term argv[])
     assert(type == VALUE_ATOM);
     // Trap caller waiting for completion
     context_update_flags(ctx, ~NoFlags, Trap);
-    emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VIIII, do_get_tracked_object, NULL, ref_keys, n, ctx->process_id, ctx->global);
+    emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VIIII, do_get_tracked_objects, NULL, ref_keys, n, ctx->process_id, ctx->global);
     return term_invalid_term();
 }
 

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -197,7 +197,10 @@ static void do_run_script_tracked(const char *script, int32_t sync_caller_pid, G
         free(keys);
         mailbox_send_term_signal(target_ctx, TrapAnswerSignal, result);
         globalcontext_get_process_unlock(global, target_ctx);
-    } // else: sender died
+    } else {
+        // sender died
+        free(keys);
+    }
 }
 
 static term nif_emscripten_run_script_tracked(Context *ctx, int argc, term argv[])

--- a/src/platforms/emscripten/src/lib/platform_nifs.c
+++ b/src/platforms/emscripten/src/lib/platform_nifs.c
@@ -278,6 +278,41 @@ static term nif_emscripten_from_remote_object(Context *ctx, int argc, term argv[
     }
 }
 
+static term nif_emscripten_run_script_tracked(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    UNUSED(argv);
+    if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2) + CONS_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    term values = term_nil();
+    values = term_list_prepend(term_from_int(1), values, &ctx->heap);
+
+    term result_tuple = term_alloc_tuple(2, &ctx->heap);
+    term_put_tuple_element(result_tuple, 0, OK_ATOM);
+    term_put_tuple_element(result_tuple, 1, values);
+    return result_tuple;
+}
+
+static term nif_emscripten_get_tracked(Context *ctx, int argc, term argv[])
+{
+    UNUSED(ctx);
+    UNUSED(argc);
+    UNUSED(argv);
+
+    if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2) + CONS_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+
+    term values = term_nil();
+    values = term_list_prepend(term_from_int(1), values, &ctx->heap);
+
+    term result_tuple = term_alloc_tuple(2, &ctx->heap);
+    term_put_tuple_element(result_tuple, 0, OK_ATOM);
+    term_put_tuple_element(result_tuple, 1, values);
+    return result_tuple;
+}
+
 static term nif_emscripten_promise_resolve_reject(Context *ctx, int argc, term argv[], em_promise_result_t result)
 {
     struct EmscriptenPlatformData *platform = ctx->global->platform_data;
@@ -334,6 +369,14 @@ static const struct Nif emscripten_run_remote_object_script_fn = {
 static const struct Nif emscripten_from_remote_object = {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_emscripten_from_remote_object,
+};
+static const struct Nif emscripten_run_script_tracked = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_emscripten_run_script_tracked
+};
+static const struct Nif emscripten_get_tracked = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_emscripten_get_tracked,
 };
 static const struct Nif emscripten_promise_resolve_nif = {
     .base.type = NIFFunctionType,
@@ -957,6 +1000,12 @@ const struct Nif *platform_nifs_get_nif(const char *nifname)
     }
     if (strcmp("from_remote_object/2", nifname) == 0) {
         return &emscripten_from_remote_object;
+    }
+    if (strcmp("run_script_tracked/1", nifname) == 0) {
+        return &emscripten_run_script_tracked;
+    }
+    if (strcmp("get_tracked/2", nifname) == 0) {
+        return &emscripten_get_tracked;
     }
     if (strcmp("promise_resolve/1", nifname) == 0) {
         return &emscripten_promise_resolve_nif;

--- a/src/platforms/emscripten/src/lib/sys.c
+++ b/src/platforms/emscripten/src/lib/sys.c
@@ -87,6 +87,13 @@ size_t sys_get_next_remote_object_key(GlobalContext *glb)
     return platform->next_remote_object_index++;
 }
 
+size_t sys_get_next_tracked_object_key(GlobalContext *glb)
+{
+    struct EmscriptenPlatformData *platform = glb->platform_data;
+    return platform->next_tracked_object_index++;
+}
+
+
 static void promise_dtor(ErlNifEnv *caller_env, void *obj)
 {
     UNUSED(caller_env);

--- a/src/platforms/emscripten/src/lib/sys.c
+++ b/src/platforms/emscripten/src/lib/sys.c
@@ -93,7 +93,6 @@ size_t sys_get_next_tracked_object_key(GlobalContext *glb)
     return platform->next_tracked_object_index++;
 }
 
-
 static void promise_dtor(ErlNifEnv *caller_env, void *obj)
 {
     UNUSED(caller_env);
@@ -107,10 +106,7 @@ static void promise_dtor(ErlNifEnv *caller_env, void *obj)
 
 static void do_remove_remote_object(atomic_size_t key)
 {
-    EM_ASM({
-        Module['onRemoteObjectDelete']($0);
-        Module['remoteObjectsMap'].delete($0);
-    }, key);
+    EM_ASM({ Module['onRemoteObjectDelete']($0); }, key);
 }
 
 static void remote_object_dtor(ErlNifEnv *caller_env, void *obj)

--- a/src/platforms/emscripten/src/lib/sys.c
+++ b/src/platforms/emscripten/src/lib/sys.c
@@ -81,12 +81,6 @@ void sys_promise_resolve_str_and_destroy(em_promise_t promise, em_promise_result
     emscripten_promise_destroy(promise);
 }
 
-size_t sys_get_next_remote_object_key(GlobalContext *glb)
-{
-    struct EmscriptenPlatformData *platform = glb->platform_data;
-    return platform->next_remote_object_index++;
-}
-
 size_t sys_get_next_tracked_object_key(GlobalContext *glb)
 {
     struct EmscriptenPlatformData *platform = glb->platform_data;
@@ -104,17 +98,17 @@ static void promise_dtor(ErlNifEnv *caller_env, void *obj)
     }
 }
 
-static void do_remove_remote_object(atomic_size_t key)
+static void do_remove_tracked_object(atomic_size_t key)
 {
-    EM_ASM({ Module['onRemoteObjectDelete']($0); }, key);
+    EM_ASM({ Module['onTrackedObjectDelete']($0); }, key);
 }
 
-static void remote_object_dtor(ErlNifEnv *caller_env, void *obj)
+static void tracked_object_dtor(ErlNifEnv *caller_env, void *obj)
 {
     UNUSED(caller_env);
 
-    struct RemoteObjectResource *remote_object_rsrc = (struct RemoteObjectResource *) obj;
-    emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VI, do_remove_remote_object, NULL, remote_object_rsrc->key);
+    struct TrackedObjectResource *tracked_object_rsrc = (struct TrackedObjectResource *) obj;
+    emscripten_dispatch_to_thread(emscripten_main_runtime_thread_id(), EM_FUNC_SIG_VI, do_remove_tracked_object, NULL, tracked_object_rsrc->key);
 }
 
 static void htmlevent_user_data_dtor(ErlNifEnv *caller_env, void *obj)
@@ -154,9 +148,9 @@ static const ErlNifResourceTypeInit htmlevent_user_data_resource_type_init = {
     .down = htmlevent_user_data_down,
 };
 
-static const ErlNifResourceTypeInit remote_object_resource_type_init = {
+static const ErlNifResourceTypeInit tracked_object_resource_type_init = {
     .members = 1,
-    .dtor = remote_object_dtor,
+    .dtor = tracked_object_dtor,
 };
 
 void sys_init_platform(GlobalContext *glb)
@@ -175,7 +169,6 @@ void sys_init_platform(GlobalContext *glb)
         AVM_ABORT();
     }
     list_init(&platform->messages);
-    platform->next_remote_object_index = 0;
     ErlNifEnv env;
     erl_nif_env_partial_init_from_globalcontext(&env, glb);
     platform->promise_resource_type = enif_init_resource_type(&env, "promise", &promise_resource_type_init, ERL_NIF_RT_CREATE, NULL);
@@ -188,9 +181,9 @@ void sys_init_platform(GlobalContext *glb)
         fprintf(stderr, "Cannot initialize htmlevent_user_data_resource_type");
         AVM_ABORT();
     }
-    platform->remote_object_resource_type = enif_init_resource_type(&env, "remote_object", &remote_object_resource_type_init, ERL_NIF_RT_CREATE, NULL);
-    if (IS_NULL_PTR(platform->remote_object_resource_type)) {
-        fprintf(stderr, "Cannot initialize remote_object_resource_type");
+    platform->tracked_object_resource_type = enif_init_resource_type(&env, "tracked_object", &tracked_object_resource_type_init, ERL_NIF_RT_CREATE, NULL);
+    if (IS_NULL_PTR(platform->tracked_object_resource_type)) {
+        fprintf(stderr, "Cannot initialize tracked_object_resource_type");
         AVM_ABORT();
     }
     glb->platform_data = platform;

--- a/src/platforms/emscripten/src/main.c
+++ b/src/platforms/emscripten/src/main.c
@@ -147,12 +147,6 @@ em_promise_t call(const char *name, const char *message)
 }
 
 EMSCRIPTEN_KEEPALIVE
-size_t next_remote_object_key()
-{
-    return sys_get_next_remote_object_key(global);
-}
-
-EMSCRIPTEN_KEEPALIVE
 size_t next_tracked_object_key()
 {
     return sys_get_next_tracked_object_key(global);

--- a/src/platforms/emscripten/src/main.c
+++ b/src/platforms/emscripten/src/main.c
@@ -152,6 +152,12 @@ size_t next_remote_object_key()
     return sys_get_next_remote_object_key(global);
 }
 
+EMSCRIPTEN_KEEPALIVE
+size_t next_tracked_object_key()
+{
+    return sys_get_next_tracked_object_key(global);
+}
+
 /**
  * @brief Emscripten entry point
  * @details For node builds, this function is run in the main thread. For web


### PR DESCRIPTION
## In previous episode

- `:emscripten.run_remote_object_script_fn(js_fn, opts) -> RemoteObject.t()`
- `:emscripten.from_remote_object(remote_refs, :key | :value) -> term()`

This API had some shortcomings (apart from terrible naming) – they worked on individual objects, which created a lot of overhead when trying to keep track of multiple JS values.
JS code was expected to be a string with a function taking Wasm module and generated key (used to keep identity for value returned from JS function) and returning any object or undefined if tracking wasn't necessary.

Additionally, we supported similar options like in `run_js` but only in some combinations, as JS code was necessarily run on main thread only. The implementation was strongly tied to remoteObject property in Wasm module and did tracking inside compiled JS code.

## New API

New API has the following surface:
- `:emscripten.run_script_tracked(js_code) -> [TrackedObject.t()]`
- `:emscripten.get_tracked(tracked_refs, :key | :value) -> [{:ok, term()} | {:error, term()}]`

It renames `RemoteObject` to `TrackedObject` which better reflects intent.
They use JS function callbacks on Wasm module which allows to overwrite entire implementation in downstream libraries (e.g. Popcorn). Requirement for `run_script_tracked` is to work on list of numeric keys that identify values returned from eval'd script. Requirement for `get_tracked` is to work on values that are strings.

## JS code evaluation

We require passed `js_code` to be a string of JS code which returns an array or undefined. It's always run on main thread and doesn't take options.
This code is passed to `onRunTrackedJs` which is required to evaluate and return a list of keys that track values from JS array. `onRunTrackedJs` generates the keys by using exported to Wasm `get_next_tracked_object_key` function.

> [!NOTE]
>  Returned refs aren't required to have 1:1 correspondence with values returned from JS function.

## Value retrieval
To retrieve a value, list of refs is passed to the `get_tracked` which calls `onGetTrackedObjects` on Wasm module. It's required to return list of strings. If any returned value in this list isn't a string (undefined maps to "key not found", others map to "invalid returned value") it's reported as an error. All returned values are treated independently.

This allows to retrieve multiple keys at once and splitting the output into valid and invalid sets of values.

> [!NOTE]
>  Order is preserved in list of values returned from `get_tracked` but it doesn't currently have key included. For non-1:1 mapping between keys and values this can be worked around by pushing additional values at the start or end of the returned list.

## Improvements

- `get_next_tracked_object_key` should return range of values instead of single value.

## License agreement

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
