### PR TITLE
Disable process crash reports by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option(COVERAGE "Build for code coverage" OFF)
 set(SANITIZER "address" CACHE STRING "Enable Address Sanitizer") # Include address, memory, or undefined sanitizer
 option(DEBUG_ASSERTIONS ON)
 option(DEBUG_GC "Sets Heap Growth strategy to MinimumHeapGrowth, triggers GC whenever possible" OFF)
+option(GENERATE_PROCESS_CRASH_REPORTS "Print crash reports when processes die with non-standard reasons" OFF)
 
 if((${CMAKE_SYSTEM_NAME} STREQUAL "Darwin") OR
    (${CMAKE_SYSTEM_NAME} STREQUAL "Linux") OR

--- a/src/libAtomVM/CMakeLists.txt
+++ b/src/libAtomVM/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SOURCE_FILES
     nifs.c
     port.c
     posix_nifs.c
+    process_crash_report.c
     refc_binary.c
     resources.c
     scheduler.c
@@ -136,6 +137,10 @@ if (ADVANCED_TRACING)
     if (ADVANCED_TRACING_STDERR)
         target_compile_definitions(libAtomVM PUBLIC ADVANCED_TRACING_STDERR)
     endif()
+endif()
+
+if (GENERATE_PROCESS_CRASH_REPORTS)
+    target_compile_definitions(libAtomVM PUBLIC AVM_PROCESS_CRASH_REPORTS)
 endif()
 
 if(SANITIZER STREQUAL "address")

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -5688,8 +5688,6 @@ static term nif_code_load_binary(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    term file_name = argv[1];
-
     term binary = argv[2];
     if (UNLIKELY(!term_is_binary(binary))) {
         RAISE_ERROR(BADARG_ATOM);

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -32,6 +32,7 @@
 #include "exportedfunction.h"
 #include "nifs.h"
 #include "opcodes.h"
+#include "process_crash_report.h"
 #include "scheduler.h"
 #include "utils.h"
 
@@ -1325,111 +1326,6 @@ static int get_catch_label_and_change_module(Context *ctx, Module **mod)
     }
 
     return 0;
-}
-
-COLD_FUNC static void cp_to_mod_lbl_off(term cp, Context *ctx, Module **cp_mod, int *label, int *l_off)
-{
-    Module *mod = globalcontext_get_module_by_index(ctx->global, MODULE_INDEX_FROM_CP(cp));
-    long mod_offset = MODULE_OFFSET_FROM_CP(cp);
-
-    *cp_mod = mod;
-
-    uint8_t *code = &mod->code->code[0];
-    int labels_count = ENDIAN_SWAP_32(mod->code->labels);
-
-    int i = 1;
-    const uint8_t *l = mod->labels[1];
-    while (mod_offset > l - code) {
-        i++;
-        if (i >= labels_count) {
-            // last label + 1 is reserved for end of module.
-            *label = i;
-            *l_off = 0;
-            return;
-        }
-        l = mod->labels[i];
-    }
-
-    *label = i - 1;
-    *l_off = mod_offset - (mod->labels[*label] - code);
-}
-
-COLD_FUNC static void dump(Context *ctx)
-{
-    fprintf(stderr, "CRASH \n======\n");
-
-    fprintf(stderr, "pid: ");
-    term_display(stderr, term_from_local_process_id(ctx->process_id), ctx);
-    fprintf(stderr, "\n");
-
-    term stacktrace = stacktrace_ensure_built(ctx, &ctx->x[2], 3);
-    stacktrace_print(stderr, stacktrace, ctx);
-
-    {
-        Module *cp_mod;
-        int label;
-        int offset;
-        cp_to_mod_lbl_off(ctx->cp, ctx, &cp_mod, &label, &offset);
-        fprintf(stderr, "cp: #CP<module: %i, label: %i, offset: %i>\n\n",
-            cp_mod->module_index, label, offset);
-    }
-
-    fprintf(stderr, "x[0]: ");
-    term_display(stderr, ctx->x[0], ctx);
-    fprintf(stderr, "\nx[1]: ");
-    term_display(stderr, ctx->x[1], ctx);
-    fprintf(stderr, "\nx[2]: ");
-    term_display(stderr, ctx->x[2], ctx);
-    fprintf(stderr, "\n\nStack \n------\n\n");
-
-    term *ct = ctx->e;
-
-    while (ct != ctx->heap.heap_end) {
-        if (term_is_catch_label(*ct)) {
-            int target_module;
-            int target_label = term_to_catch_label_and_module(*ct, &target_module);
-            fprintf(stderr, "catch: %i:%i\n", target_label, target_module);
-
-        } else if (term_is_cp(*ct)) {
-            Module *cp_mod;
-            int label;
-            int offset;
-            cp_to_mod_lbl_off(*ct, ctx, &cp_mod, &label, &offset);
-            fprintf(stderr, "#CP<module: %i, label: %i, offset: %i>\n", cp_mod->module_index, label, offset);
-
-        } else {
-            term_display(stderr, *ct, ctx);
-            fprintf(stderr, "\n");
-        }
-
-        ct++;
-    }
-
-    fprintf(stderr, "\n\nMailbox\n--------\n");
-    mailbox_crashdump(ctx);
-
-    fprintf(stderr, "\n\nMonitors\n--------\n");
-    // Lock processes table to make sure any dying process will not modify monitors
-    struct ListHead *processes_table = synclist_rdlock(&ctx->global->processes_table);
-    UNUSED(processes_table);
-    struct ListHead *item;
-    LIST_FOR_EACH (item, &ctx->monitors_head) {
-        struct Monitor *monitor = GET_LIST_ENTRY(item, struct Monitor, monitor_list_head);
-        if (term_is_pid(monitor->monitor_obj)) {
-            term_display(stderr, monitor->monitor_obj, ctx);
-        } else {
-            fprintf(stderr, "<resource %p>", (void *) term_to_const_term_ptr(monitor->monitor_obj));
-        }
-        fprintf(stderr, " ");
-        if (monitor->ref_ticks == 0) {
-            fprintf(stderr, "<");
-        }
-        fprintf(stderr, "---> ");
-        term_display(stderr, term_from_local_process_id(ctx->process_id), ctx);
-        fprintf(stderr, "\n");
-    }
-    synclist_unlock(&ctx->global->processes_table);
-    fprintf(stderr, "\n\n**End Of Crash Report**\n");
 }
 
 static term maybe_alloc_boxed_integer_fragment(Context *ctx, avm_int64_t value)
@@ -7122,7 +7018,7 @@ handle_error:
 
         // Do not print crash dump if reason is normal or shutdown.
         if (x_regs[0] != LOWERCASE_EXIT_ATOM || (x_regs[1] != NORMAL_ATOM && x_regs[1] != SHUTDOWN_ATOM)) {
-            dump(ctx);
+            process_crash_report_print(ctx);
         }
 
         if (x_regs[0] == LOWERCASE_EXIT_ATOM) {

--- a/src/libAtomVM/process_crash_report.c
+++ b/src/libAtomVM/process_crash_report.c
@@ -1,0 +1,118 @@
+#include "process_crash_report.h"
+#include "module.h"
+#include "stacktrace.h"
+
+#ifndef AVM_PROCESS_CRASH_DUMPS
+
+COLD_FUNC void process_crash_report_print(Context *ctx)
+{
+    (void) ctx;
+}
+
+#else
+
+COLD_FUNC static void cp_to_mod_lbl_off(term cp, Context *ctx, Module **cp_mod, int *label, int *l_off)
+{
+    Module *mod = globalcontext_get_module_by_index(ctx->global, MODULE_INDEX_FROM_CP(cp));
+    long mod_offset = MODULE_OFFSET_FROM_CP(cp);
+
+    *cp_mod = mod;
+
+    uint8_t *code = &mod->code->code[0];
+    int labels_count = ENDIAN_SWAP_32(mod->code->labels);
+
+    int i = 1;
+    const uint8_t *l = mod->labels[1];
+    while (mod_offset > l - code) {
+        i++;
+        if (i >= labels_count) {
+            // last label + 1 is reserved for end of module.
+            *label = i;
+            *l_off = 0;
+            return;
+        }
+        l = mod->labels[i];
+    }
+
+    *label = i - 1;
+    *l_off = mod_offset - (mod->labels[*label] - code);
+}
+
+COLD_FUNC void process_crash_report_print(Context *ctx)
+{
+    fprintf(stderr, "CRASH \n======\n");
+
+    fprintf(stderr, "pid: ");
+    term_display(stderr, term_from_local_process_id(ctx->process_id), ctx);
+    fprintf(stderr, "\n");
+
+    term stacktrace = stacktrace_ensure_built(ctx, &ctx->x[2], 3);
+    stacktrace_print(stderr, stacktrace, ctx);
+
+    {
+        Module *cp_mod;
+        int label;
+        int offset;
+        cp_to_mod_lbl_off(ctx->cp, ctx, &cp_mod, &label, &offset);
+        fprintf(stderr, "cp: #CP<module: %i, label: %i, offset: %i>\n\n",
+            cp_mod->module_index, label, offset);
+    }
+
+    fprintf(stderr, "x[0]: ");
+    term_display(stderr, ctx->x[0], ctx);
+    fprintf(stderr, "\nx[1]: ");
+    term_display(stderr, ctx->x[1], ctx);
+    fprintf(stderr, "\nx[2]: ");
+    term_display(stderr, ctx->x[2], ctx);
+    fprintf(stderr, "\n\nStack \n------\n\n");
+
+    term *ct = ctx->e;
+
+    while (ct != ctx->heap.heap_end) {
+        if (term_is_catch_label(*ct)) {
+            int target_module;
+            int target_label = term_to_catch_label_and_module(*ct, &target_module);
+            fprintf(stderr, "catch: %i:%i\n", target_label, target_module);
+
+        } else if (term_is_cp(*ct)) {
+            Module *cp_mod;
+            int label;
+            int offset;
+            cp_to_mod_lbl_off(*ct, ctx, &cp_mod, &label, &offset);
+            fprintf(stderr, "#CP<module: %i, label: %i, offset: %i>\n", cp_mod->module_index, label, offset);
+
+        } else {
+            term_display(stderr, *ct, ctx);
+            fprintf(stderr, "\n");
+        }
+
+        ct++;
+    }
+
+    fprintf(stderr, "\n\nMailbox\n--------\n");
+    mailbox_crashdump(ctx);
+
+    fprintf(stderr, "\n\nMonitors\n--------\n");
+    // Lock processes table to make sure any dying process will not modify monitors
+    struct ListHead *processes_table = synclist_rdlock(&ctx->global->processes_table);
+    UNUSED(processes_table);
+    struct ListHead *item;
+    LIST_FOR_EACH (item, &ctx->monitors_head) {
+        struct Monitor *monitor = GET_LIST_ENTRY(item, struct Monitor, monitor_list_head);
+        if (term_is_pid(monitor->monitor_obj)) {
+            term_display(stderr, monitor->monitor_obj, ctx);
+        } else {
+            fprintf(stderr, "<resource %p>", (void *) term_to_const_term_ptr(monitor->monitor_obj));
+        }
+        fprintf(stderr, " ");
+        if (monitor->ref_ticks == 0) {
+            fprintf(stderr, "<");
+        }
+        fprintf(stderr, "---> ");
+        term_display(stderr, term_from_local_process_id(ctx->process_id), ctx);
+        fprintf(stderr, "\n");
+    }
+    synclist_unlock(&ctx->global->processes_table);
+    fprintf(stderr, "\n\n**End Of Crash Report**\n");
+}
+#endif

--- a/src/libAtomVM/process_crash_report.h
+++ b/src/libAtomVM/process_crash_report.h
@@ -1,0 +1,21 @@
+/*
+ * This file is part of AtomVM.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+#include "module.h"
+
+void process_crash_report_print(Context *ctx);


### PR DESCRIPTION
blocked by https://github.com/software-mansion/popcorn/issues/178
closes https://github.com/software-mansion/popcorn/issues/179

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
