### PR TITLE
Fix rand uniform

### DIFF
--- a/libs/eavmlib/src/CMakeLists.txt
+++ b/libs/eavmlib/src/CMakeLists.txt
@@ -26,6 +26,7 @@ set(ERLANG_MODULES
     ahttp_client
     atomvm
     avm_pubsub
+    avm_rand
     console
     emscripten
     esp

--- a/libs/eavmlib/src/avm_rand.erl
+++ b/libs/eavmlib/src/avm_rand.erl
@@ -1,0 +1,6 @@
+-module(avm_rand).
+
+-export([splitmix64_next/1]).
+
+splitmix64_next(_X) ->
+  erlang:error(splitmix64_next_nif_missing).

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+elixir = "1.17.3-otp-26"
+erlang = "26.0.2"
+rebar = "latest"

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -20,6 +20,7 @@
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#include <stdint.h>
 #endif
 
 #include "nifs.h"
@@ -228,6 +229,7 @@ static term nif_erlang_lists_subtract(Context *ctx, int argc, term argv[]);
 static term nif_zlib_compress_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_nif_error_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_bump_reductions_1(Context *ctx, int argc, term argv[]);
+static term nif_rand_splitmix64_next(Context *ctx, int argc, term argv[]);
 
 #define DECLARE_MATH_NIF_FUN(moniker) \
     static term nif_math_##moniker(Context *ctx, int argc, term argv[]);
@@ -972,6 +974,11 @@ static const struct Nif erlang_bump_reductions_nif = {
     .nif_ptr = nif_erlang_bump_reductions_1
 };
 
+static const struct Nif rand_splitmix64_next_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_rand_splitmix64_next
+};
+
 #define DEFINE_MATH_NIF(moniker)                    \
     static const struct Nif math_##moniker##_nif =  \
     {                                               \
@@ -1079,7 +1086,7 @@ static inline term make_maybe_boxed_int64(Context *ctx, avm_int64_t value)
     #endif
 
     if ((value < MIN_NOT_BOXED_INT) || (value > MAX_NOT_BOXED_INT)) {
-        if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_opt(ctx, BOXED_INT64_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         }
         return term_make_boxed_int(value, &ctx->heap);
@@ -5688,8 +5695,6 @@ static term nif_code_load_binary(Context *ctx, int argc, term argv[])
         RAISE_ERROR(BADARG_ATOM);
     }
 
-    term file_name = argv[1];
-
     term binary = argv[2];
     if (UNLIKELY(!term_is_binary(binary))) {
         RAISE_ERROR(BADARG_ATOM);
@@ -6450,6 +6455,25 @@ static term nif_erlang_bump_reductions_1(Context *ctx, int argc, term argv[])
     return TRUE_ATOM;
 }
 
+static term nif_rand_splitmix64_next(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    VALIDATE_VALUE(argv[0], term_is_any_integer);
+    uint64_t x = term_maybe_unbox_int64(argv[0]);
+    // implementation based on https://github.com/erlang/otp/blob/d051172925a5c84b2f21850a188a533f885f201c/lib/stdlib/src/rand.erl#L1629
+    uint64_t z = (x += 0x9e3779b97f4a7c15);
+    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
+    z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
+    z = z ^ (z >> 31);
+    // assume pessimisticly both ints will be boxed
+    if (UNLIKELY(memory_ensure_free_opt(ctx, TUPLE_SIZE(2) + 2 * BOXED_INT64_SIZE, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+      RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+    }
+    term result = term_alloc_tuple(2, &ctx->heap);
+    term_put_tuple_element(result, 0, term_make_maybe_boxed_int64(z, &ctx->heap));
+    term_put_tuple_element(result, 1, term_make_maybe_boxed_int64(x, &ctx->heap));
+    return result;
+}
 //
 // MAINTENANCE NOTE: Exception handling for fp operations using math
 // error handling is designed to be thread-safe, as errors are specified

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -200,6 +200,7 @@ unicode:characters_to_list/2, &unicode_characters_to_list_nif
 unicode:characters_to_binary/1, &unicode_characters_to_binary_nif
 unicode:characters_to_binary/2, &unicode_characters_to_binary_nif
 unicode:characters_to_binary/3, &unicode_characters_to_binary_nif
+avm_rand:splitmix64_next/1, &rand_splitmix64_next_nif
 math:acos/1, &math_acos_nif
 math:acosh/1, &math_acosh_nif
 math:asin/1, &math_asin_nif

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -234,10 +234,14 @@ typedef dreg_t dreg_gc_safe_t;
                 case COMPACT_NBITS_VALUE:{                                              \
                     int sz = (first_byte >> 5) + 2;                                     \
                     if (UNLIKELY(sz > 8)) {                                             \
-                        /* TODO: when first_byte >> 5 is 7, a different encoding is used */ \
-                        fprintf(stderr, "Unexpected nbits value @ %" PRIuPTR "\n", (uintptr_t) ((decode_pc) - 1)); \
-                        AVM_ABORT();                                                    \
-                        break;                                                          \
+                      sz = *(decode_pc) + 9;                                            \
+                      (decode_pc)++;                                                    \
+                      /* Integer larger than 60-bits but no bigger than 64-bits */      \
+                      /* will become boxed term taking 9 bytes (1 byte box + 64 bits)*/ \
+                      /* AtomVM can handle 64 bit int, but not larger ones until BigNum support is ready*/ \
+                      if (sz > 9 && (first_byte & 0xF) == COMPACT_LARGE_INTEGER) {      \
+                        fprintf(stderr, "WARNING: Loading integer possibly longer than 64 bits"); \
+                      }                                                                 \
                     }                                                                   \
                     (decode_pc) += sz;                                                  \
                     break;                                                              \


### PR DESCRIPTION
These changes allow to patch `rand:splitmix64_next/1` function, replacing Erlang implementation with a native one handling 64-bit integer rollover