### PR TITLE
Fixed reraise not caught error

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           git clone git@github.com:software-mansion/popcorn.git
           cd popcorn
-          echo "import Config; config :popcorn, target: :unix, runtime_source: {:path, \"..\"}" > config/config.secret.exs
+          echo "import Config; config :popcorn, target: :unix, runtime: {:path, \"../build/src\"}" > config/config.secret.exs
           mix deps.get
           export PATH=$PATH:/home/runner/.mix/elixir/1-17/ # for rebar3
           MIX_ENV=test mix popcorn.build_runtime --target unix

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1332,6 +1332,10 @@ static int get_catch_label_and_change_module(Context *ctx, Module **mod)
     return 0;
 }
 
+static bool is_exception_class(term t) {
+    return t == ERROR_ATOM || t == LOWERCASE_EXIT_ATOM || t == THROW_ATOM;
+}
+
 static term maybe_alloc_boxed_integer_fragment(Context *ctx, avm_int64_t value)
 {
 #if BOXED_TERMS_REQUIRED_FOR_INT64 > 1
@@ -3603,6 +3607,12 @@ wait_timeout_trap_handler:
                 #ifdef IMPL_EXECUTE_LOOP
                     TRACE("raise/2 stacktrace=0x%lx exc_value=0x%lx\n", stacktrace, exc_value);
                     if (stacktrace_is_built(stacktrace)) {
+                        //  FIXME: This is a temporary solution as in some niche cases of reraise the x_regs[0] is
+                        //  overwritten and it does not represent exception class
+                        if (!is_exception_class(x_regs[0])) {
+                            x_regs[0] = ERROR_ATOM;
+                        }
+                        x_regs[1] = exc_value;
                         x_regs[2] = stacktrace;
                     } else {
                         x_regs[0] = stacktrace_exception_class(stacktrace);


### PR DESCRIPTION
The xregs[0] is overwritten while reraising in AtomVM, the OP_RAISE opcode expects exception_class in xregs[0].
This corner case happens when we tried to catch the exception raised in Code.eval_string outside of it.
```
try do
  """
  raise("oops")
  """
  |> Code.eval_string([], __ENV__)
rescue
  e -> e
end
 ```