### PR TITLE
Call Module['onWorkerError'] in the main JS thread on abort

### DIFF
--- a/src/platforms/emscripten/src/atomvm.pre.js
+++ b/src/platforms/emscripten/src/atomvm.pre.js
@@ -57,6 +57,16 @@ Module["onRunTrackedJs"] = (scriptString, isDebug) => {
   isDebug && ensureValidResult(result);
   return result?.map(trackValue) ?? [];
 };
+
+// This is a workaround for handling the ABORT signal. It effectively calls
+// Module["onWorkerError"] from the main JS thread. The onAbort callback is called
+// within the worker just before it's terminated. The worker doesn't have access to
+// window nor DOM, so we need to communicate with the main JS thread. It seems that
+// this is the only option.
+Module["onAbort"] = (error) => {
+  postMessage({ cmd: "callHandler", handler: "onWorkerError", args: [error] })
+};
+
 function ensureValidResult(result) {
   const isIndex = (k) => typeof k === "number";
 


### PR DESCRIPTION
See https://github.com/software-mansion/popcorn/pull/283

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
