### PR TITLE
Add `short` option to `erlang:float_to_binary/2` & `erlang:float_to_binary/2`

### DIFF
--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -144,7 +144,8 @@
 -type float_format_option() ::
     {decimals, Decimals :: 0..57}
     | {scientific, Decimals :: 0..57}
-    | compact.
+    | compact
+    | short.
 
 -type demonitor_option() :: flush | {flush, boolean()} | info | {info, boolean()}.
 

--- a/src/libAtomVM/defaultatoms.def
+++ b/src/libAtomVM/defaultatoms.def
@@ -55,6 +55,7 @@ X(REDUCTIONS_ATOM, "\xA", "reductions")
 X(DECIMALS_ATOM, "\x8", "decimals")
 X(SCIENTIFIC_ATOM, "\xA", "scientific")
 X(DEFAULTATOMS_COMPACT_ATOM, "\x7", "compact")
+X(SHORT_ATOM, "\x5", "short")
 
 X(BADMATCH_ATOM, "\x8", "badmatch")
 X(CASE_CLAUSE_ATOM, "\xB", "case_clause")

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2628,7 +2628,13 @@ int get_float_format_opts(term opts, int *scientific, int *decimals, int *compac
     while (term_is_nonempty_list(t)) {
         term head = term_get_list_head(t);
 
-        if (term_is_tuple(head) && term_get_tuple_arity(head) == 2) {
+        if (head == SHORT_ATOM) {
+            // FIXME: OTP uses ryu algorithm for short format, vendored as a lib (https://github.com/erlang/otp/tree/master/erts/emulator/ryu)
+            // Workaround here uses default decimal precision with compacting
+            *scientific = 0;
+            *decimals = 10;
+            *compact = 1;
+        } else if (term_is_tuple(head) && term_get_tuple_arity(head) == 2) {
             term val_term = term_get_tuple_element(head, 1);
             if (!term_is_integer(val_term)) {
                 return 0;

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -241,7 +241,7 @@ typedef dreg_t dreg_gc_safe_t;
                       /* will become boxed term taking 9 bytes (1 byte box + 64 bits)*/ \
                       /* AtomVM can handle 64 bit int, but not larger ones until BigNum support is ready*/ \
                       if (sz > 9 && (first_byte & 0xF) == COMPACT_LARGE_INTEGER) {      \
-                        fprintf(stderr, "WARNING: Loading integer possibly longer than 64 bits"); \
+                        fprintf(stderr, "WARNING: Loading integer longer than 64 bits (sz = %d)\n", sz); \
                       }                                                                 \
                     }                                                                   \
                     (decode_pc) += sz;                                                  \

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -398,6 +398,7 @@ compile_erlang(float2list)
 compile_erlang(float2bin)
 compile_erlang(float2bin2decimals)
 compile_erlang(float2bin2scientific)
+compile_erlang(float2bin2short)
 compile_erlang(float2bin2)
 compile_erlang(float2list2decimals)
 compile_erlang(float2list2scientific)
@@ -892,6 +893,7 @@ add_custom_target(erlang_test_modules DEPENDS
     float2bin.beam
     float2bin2decimals.beam
     float2bin2scientific.beam
+    float2bin2short.beam
     float2bin2.beam
     float2list2decimals.beam
     float2list2scientific.beam

--- a/tests/erlang_tests/float2bin2short.erl
+++ b/tests/erlang_tests/float2bin2short.erl
@@ -1,0 +1,77 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Bartosz Błaszków <bartosz.blaszkow@swmansion.com>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(float2bin2short).
+
+-export([start/0]).
+
+% FIXME: When short is properly implemented, add cases when the representation
+% becomes shorter using expotential notation, e.g.
+% 1/1_000_000 => "1.0e-6"
+start() ->
+  F1 = id(add(id(2.5), id(-1.0))),
+  Bin1 = id(erlang:float_to_binary(id(F1), [short])),
+  F2 = id(id(F1) + id(id(0.5) * id(-1.0))),
+  Bin2 = id(erlang:float_to_binary(id(F2), [short])),
+  F3 = id(id(F2) * id(-1.0)),
+  Bin3 = id(erlang:float_to_binary(id(F3), [short])),
+  F4 = id(add(id(F2), id(F3))),
+  Bin4 = id(erlang:float_to_binary(id(F4), [short])),
+  compare_bin(Bin1, id(<<"1.5">>))
+  + compare_bin(Bin2, id(<<"1.0">>)) * 2
+  + compare_bin(Bin3, id(<<"-1.0">>)) * 4
+  + compare_bin(Bin4, id(<<"0.0">>)) * 8
+  + float_to_bin_badarg({1}, [short]) * 16
+  + float_to_bin_badarg(F4, [{short, 1}]) * 32.
+
+add(A, B) when is_float(A) and is_float(B) ->
+  id(id(A) + id(B)).
+
+compare_bin(Bin1, Bin2) when byte_size(Bin1) == byte_size(Bin2) ->
+  compare_bin(Bin1, Bin2, byte_size(Bin1) - 1);
+compare_bin(_Bin1, _Bin2) ->
+  0.
+
+compare_bin(_Bin1, _Bin2, -1) ->
+  1;
+compare_bin(Bin1, Bin2, Index) ->
+  B1 = binary:at(Bin1, Index),
+  case binary:at(Bin2, Index) of
+    B1 ->
+      compare_bin(Bin1, Bin2, Index - 1);
+    _Any ->
+      0
+  end.
+
+id(I) when is_float(I) ->
+  I;
+id(I) when is_binary(I) ->
+  I.
+
+float_to_bin_badarg(F, O) ->
+  try erlang:float_to_binary(F, O) of
+    Res ->
+      Res
+  catch
+    error:badarg ->
+      1;
+    _:_ ->
+      -1
+  end.

--- a/tests/erlang_tests/float2bin2short.erl
+++ b/tests/erlang_tests/float2bin2short.erl
@@ -21,43 +21,44 @@
 -module(float2bin2short).
 
 -export([start/0]).
+-export([id/1]).
+
+-define(ID(Arg), ?MODULE:id(Arg)).
 
 % FIXME: When short is properly implemented, add cases when the representation
 % becomes shorter using expotential notation, e.g.
 % 1/1_000_000 => "1.0e-6"
 start() ->
-  F1 = id(add(id(2.5), id(-1.0))),
-  Bin1 = id(erlang:float_to_binary(id(F1), [short])),
-  F2 = id(id(F1) + id(id(0.5) * id(-1.0))),
-  Bin2 = id(erlang:float_to_binary(id(F2), [short])),
-  F3 = id(id(F2) * id(-1.0)),
-  Bin3 = id(erlang:float_to_binary(id(F3), [short])),
-  F4 = id(add(id(F2), id(F3))),
-  Bin4 = id(erlang:float_to_binary(id(F4), [short])),
-  compare_bin(Bin1, id(<<"1.5">>))
-  + compare_bin(Bin2, id(<<"1.0">>)) * 2
-  + compare_bin(Bin3, id(<<"-1.0">>)) * 4
-  + compare_bin(Bin4, id(<<"0.0">>)) * 8
-  + float_to_bin_badarg({1}, [short]) * 16
-  + float_to_bin_badarg(F4, [{short, 1}]) * 32.
-
-add(A, B) when is_float(A) and is_float(B) ->
-  id(id(A) + id(B)).
-
-compare_bin(Bin1, Bin2) when byte_size(Bin1) == byte_size(Bin2) ->
-  compare_bin(Bin1, Bin2, byte_size(Bin1) - 1);
-compare_bin(_Bin1, _Bin2) ->
+  F1 = ?ID(2.5) + ?ID(-1.0),
+  Bin1 = erlang:float_to_binary(?ID(F1), [short]),
+  F2 = ?ID(F1) + ?ID(0.5) * ?ID(-1.0),
+  Bin2 = erlang:float_to_binary(?ID(F2), [short]),
+  F3 = ?ID(F2) * ?ID(-1.0),
+  Bin3 = id(erlang:float_to_binary(?ID(F3), [short])),
+  F4 = ?ID(F2) + ?ID(F3),
+  Bin4 = erlang:float_to_binary(?ID(F4), [short]),
+  true = assert_bin_equal(Bin1, ?ID(<<"1.5">>)),
+  true = assert_bin_equal(Bin2, ?ID(<<"1.0">>)),
+  true = assert_bin_equal(Bin3, ?ID(<<"-1.0">>)),
+  true = assert_bin_equal(Bin4, ?ID(<<"0.0">>)),
+  true = assert_float_to_bin_badarg({1}, [short]),
+  true = assert_float_to_bin_badarg(F4, [{short, 1}]),
   0.
 
+assert_bin_equal(Bin1, Bin2) when byte_size(Bin1) == byte_size(Bin2) ->
+  compare_bin(Bin1, Bin2, byte_size(Bin1) - 1);
+assert_bin_equal(_Bin1, _Bin2) ->
+  false.
+
 compare_bin(_Bin1, _Bin2, -1) ->
-  1;
+  true;
 compare_bin(Bin1, Bin2, Index) ->
   B1 = binary:at(Bin1, Index),
   case binary:at(Bin2, Index) of
     B1 ->
       compare_bin(Bin1, Bin2, Index - 1);
     _Any ->
-      0
+      false
   end.
 
 id(I) when is_float(I) ->
@@ -65,13 +66,13 @@ id(I) when is_float(I) ->
 id(I) when is_binary(I) ->
   I.
 
-float_to_bin_badarg(F, O) ->
+assert_float_to_bin_badarg(F, O) ->
   try erlang:float_to_binary(F, O) of
-    Res ->
-      Res
+    _Res ->
+      false
   catch
     error:badarg ->
-      1;
+      true;
     _:_ ->
-      -1
+      false
   end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -447,6 +447,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(float2list, 31),
     TEST_CASE_EXPECTED(float2bin2scientific, 31),
     TEST_CASE_EXPECTED(float2bin2decimals, 255),
+    TEST_CASE_EXPECTED(float2bin2short, 63),
     TEST_CASE_EXPECTED(float2bin2, 31),
     TEST_CASE_EXPECTED(float2list2scientific, 31),
     TEST_CASE(float_bif),

--- a/tests/test.c
+++ b/tests/test.c
@@ -447,7 +447,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(float2list, 31),
     TEST_CASE_EXPECTED(float2bin2scientific, 31),
     TEST_CASE_EXPECTED(float2bin2decimals, 255),
-    TEST_CASE_EXPECTED(float2bin2short, 63),
+    TEST_CASE(float2bin2short),
     TEST_CASE_EXPECTED(float2bin2, 31),
     TEST_CASE_EXPECTED(float2list2scientific, 31),
     TEST_CASE(float_bif),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
