### PR TITLE
Implement `erlang:display_string` BIF

### DIFF
--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -51,6 +51,8 @@
     erase/1,
     function_exported/3,
     display/1,
+    display_string/1,
+    display_string/2,
     list_to_atom/1,
     list_to_existing_atom/1,
     list_to_binary/1,
@@ -597,6 +599,32 @@ function_exported(_Module, _Function, _Arity) ->
 %%-----------------------------------------------------------------------------
 -spec display(Term :: any()) -> true.
 display(_Term) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @hidden
+%% @param   String  string or binary to print
+%% @returns `true'
+%% @doc     Prints a string to stderr. Hidden by OTP, meant for debugging.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec display_string(P1) -> true when
+      P1 :: string() | binary().
+display_string(String) ->
+    erlang:display_string(stderr, String).
+
+%%-----------------------------------------------------------------------------
+%% @hidden
+%% @param   Device  stdout or stderr. Doesn't support stdin compared to OTP
+%% @param   String  string or binary to print
+%% @returns `true'
+%% @doc     Prints a string to specified device. Hidden by OTP, meant for debugging.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec display_string(Device, P1) -> true when
+      Device :: stdout | stderr,
+      P1 :: string() | binary().
+display_string(_Stream,_P1) ->
     erlang:nif_error(undefined).
 
 %%-----------------------------------------------------------------------------

--- a/src/libAtomVM/defaultatoms.def
+++ b/src/libAtomVM/defaultatoms.def
@@ -114,6 +114,9 @@ X(UTF16_ATOM, "\x5", "utf16")
 X(UTF32_ATOM, "\x5", "utf32")
 X(BADRECORD_ATOM, "\x9", "badrecord")
 
+X(STDOUT_ATOM, "\x6", "stdout")
+X(STDERR_ATOM, "\x6", "stderr")
+
 X(COPY_ATOM, "\x4", "copy")
 X(REUSE_ATOM, "\x5", "reuse")
 X(ENSURE_AT_LEAST_ATOM, "\xF", "ensure_at_least")

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -2907,23 +2907,27 @@ static term nif_erlang_display_string_2(Context *ctx, int argc, term argv[])
     } else if (argv[0] == STDERR_ATOM) {
         fd = stderr;
     } else {
-        return RAISE_ERROR(BADARG_ATOM);
+        RAISE_ERROR(BADARG_ATOM);
     }
 
     term t = argv[1];
     if (term_is_nonempty_list(t)) {
         int ok;
         char * printable = interop_list_to_string(t, &ok);
-        if (LIKELY(ok)) {
-            fputs(printable, fd);
-            free(printable);
-        } else {
-            return RAISE_ERROR(BADARG_ATOM);
+        if (UNLIKELY(!ok)) {
+            RAISE_ERROR(BADARG_ATOM);
         }
+
+        fputs(printable, fd);
+        free(printable);
     } else if (term_is_binary(t)) {
-        int len = term_binary_size(t);
-        const char *binary_data =  term_binary_data(t);
+        size_t len = term_binary_size(t);
+        const char *binary_data = term_binary_data(t);
         fwrite(binary_data, sizeof(*binary_data), len, fd);
+    } else if (term_is_nil(t)) {
+        return TRUE_ATOM;
+    } else {
+        RAISE_ERROR(BADARG_ATOM);
     }
 
     return TRUE_ATOM;

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -126,6 +126,7 @@ static term nif_erlang_binary_to_list_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_binary_to_existing_atom_2(Context *ctx, int argc, term argv[]);
 static term nif_erlang_concat_2(Context *ctx, int argc, term argv[]);
 static term nif_erlang_display_1(Context *ctx, int argc, term argv[]);
+static term nif_erlang_display_string_2(Context *ctx, int argc, term argv[]);
 static term nif_erlang_erase_0(Context *ctx, int argc, term argv[]);
 static term nif_erlang_erase_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_error(Context *ctx, int argc, term argv[]);
@@ -377,6 +378,13 @@ static const struct Nif display_nif =
     .base.type = NIFFunctionType,
     .nif_ptr = nif_erlang_display_1
 };
+
+static const struct Nif display_string_nif =
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_erlang_display_string_2
+};
+
 
 static const struct Nif erase_0_nif = {
     .base.type = NIFFunctionType,
@@ -2884,6 +2892,39 @@ static term nif_erlang_display_1(Context *ctx, int argc, term argv[])
 
     term_display(stdout, argv[0], ctx);
     printf("\n");
+
+    return TRUE_ATOM;
+}
+
+static term nif_erlang_display_string_2(Context *ctx, int argc, term argv[])
+{
+    UNUSED(ctx);
+    UNUSED(argc);
+
+    FILE *fd;
+    if (argv[0] == STDOUT_ATOM) {
+        fd = stdout;
+    } else if (argv[0] == STDERR_ATOM) {
+        fd = stderr;
+    } else {
+        return RAISE_ERROR(BADARG_ATOM);
+    }
+
+    term t = argv[1];
+    if (term_is_nonempty_list(t)) {
+        int ok;
+        char * printable = interop_list_to_string(t, &ok);
+        if (LIKELY(ok)) {
+            fputs(printable, fd);
+            free(printable);
+        } else {
+            return RAISE_ERROR(BADARG_ATOM);
+        }
+    } else if (term_is_binary(t)) {
+        int len = term_binary_size(t);
+        const char *binary_data =  term_binary_data(t);
+        fwrite(binary_data, sizeof(*binary_data), len, fd);
+    }
 
     return TRUE_ATOM;
 }

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -67,6 +67,7 @@ erlang:error/3, &error_nif
 erlang:exit/1, &exit_nif
 erlang:exit/2, &exit_nif
 erlang:display/1, &display_nif
+erlang:display_string/2, &display_string_nif
 erlang:float_to_binary/1, &float_to_binary_nif
 erlang:float_to_binary/2, &float_to_binary_nif
 erlang:float_to_list/1, &float_to_list_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -139,6 +139,7 @@ compile_erlang(test_binary_to_atom)
 compile_erlang(test_binary_to_existing_atom)
 compile_erlang(test_atom_to_list)
 compile_erlang(test_display)
+compile_erlang(nif_erlang_display_string)
 compile_erlang(test_integer_to_list)
 compile_erlang(test_list_to_integer)
 compile_erlang(test_abs)
@@ -632,6 +633,7 @@ add_custom_target(erlang_test_modules DEPENDS
     test_binary_to_existing_atom.beam
     test_atom_to_list.beam
     test_display.beam
+    nif_erlang_display_string.beam
     test_integer_to_list.beam
     test_list_to_integer.beam
     test_abs.beam

--- a/tests/erlang_tests/nif_erlang_display_string.erl
+++ b/tests/erlang_tests/nif_erlang_display_string.erl
@@ -1,0 +1,23 @@
+-module(nif_erlang_display_string).
+
+-export([start/0, id/1]).
+
+-define(ID(Arg), ?MODULE:id(Arg)).
+
+start() ->
+  ok = test_charlist(),
+  ok = test_binary(),
+  0.
+
+test_charlist() ->
+  true = erlang:display_string(stdout, ?ID("hello\n")),
+  true = erlang:display_string(stderr, ?ID("hello\n")),
+  ok.
+
+test_binary() ->
+  true = erlang:display_string(stdout, ?ID(<<"hello\n">>)),
+  true = erlang:display_string(stderr, ?ID(<<"hello\n">>)),
+  ok.
+
+id(T) ->
+  T.

--- a/tests/erlang_tests/nif_erlang_display_string.erl
+++ b/tests/erlang_tests/nif_erlang_display_string.erl
@@ -7,17 +7,43 @@
 start() ->
   ok = test_charlist(),
   ok = test_binary(),
+  ok = test_badarg(),
   0.
 
 test_charlist() ->
   true = erlang:display_string(stdout, ?ID("hello\n")),
+  true = erlang:display_string(stdout, ?ID([])),
+
   true = erlang:display_string(stderr, ?ID("hello\n")),
+  true = erlang:display_string(stderr, ?ID([])),
   ok.
 
 test_binary() ->
   true = erlang:display_string(stdout, ?ID(<<"hello\n">>)),
+  true = erlang:display_string(stdout, ?ID(<<>>)),
+
   true = erlang:display_string(stderr, ?ID(<<"hello\n">>)),
+  true = erlang:display_string(stderr, ?ID(<<>>)),
+  ok.
+
+test_badarg() ->
+  true = assert_badarg(no_device, ?ID("hello\n")),
+  true = assert_badarg(no_device, ?ID(<<"hello\n">>)),
+  true = assert_badarg(stdout, ?ID(true)),
+  true = assert_badarg(stdout, ?ID([3.1, 0])),
+  true = assert_badarg(stdout, ?ID({ok, <<"hello\n">>})),
   ok.
 
 id(T) ->
   T.
+
+assert_badarg(Device, Chars) ->
+  try erlang:display_string(Device, Chars) of
+    _Res ->
+      false
+  catch
+    error:badarg ->
+      true;
+    _:_ ->
+      false
+  end.

--- a/tests/test.c
+++ b/tests/test.c
@@ -189,6 +189,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(test_binary_to_existing_atom, 9),
     TEST_CASE_EXPECTED(test_atom_to_list, 1),
     TEST_CASE(test_display),
+    TEST_CASE(nif_erlang_display_string),
     TEST_CASE(test_integer_to_list),
     TEST_CASE_EXPECTED(test_list_to_integer, 99),
     TEST_CASE_EXPECTED(test_abs, 5),


### PR DESCRIPTION
According to Popcorn docs, the nif is used in following functions: `Agent.Server.handle_info/2`, `DynamicSupervisor.handle_info/2`, `DynamicSupervisor.report_error/5`, `GenEvent.init_it/6`, `GenEvent.report_error/5`, `Task.Supervised.invoke_mfa/2`

It may also provide stderr printing in other functions