### PR TITLE
Add buildscript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ src/platforms/esp32/dependencies.lock
 .DS_Store
 .cache
 .clang-tidy
+
+# FissionVM out dir
+out/

--- a/build-fission.sh
+++ b/build-fission.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+set -e
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    echo "Usage: $0 [--clean] <build_mode>"
+    echo ""
+    echo "Runs cmake and builds AtomVM for specified platform and mode. Copies artifacts to out/ directory."
+    echo "Wasm artifacts are additionally compressed."
+    echo "You can pass CMake flags via 'AVM_CMAKE_OPTS', example below."
+    echo ""
+    echo "Options:"
+    echo "  --clean       - Run ninja clean before building"
+    echo "Build modes:"
+    echo "  debug-unix    - Debug build for Unix platforms"
+    echo "  debug-wasm    - Debug build for WebAssembly"
+    echo "  release-unix  - Release build for Unix platforms"
+    echo "  release-wasm  - Release build for WebAssembly"
+    echo ""
+    echo "Examples:"
+    echo "Run debug unix build:"
+    echo "  ./build-fission debug-unix"
+    echo "Run wasm debug build from scratch:"
+    echo "  ./build-fission debug-wasm --clean"
+    echo "Pass additional flags to build:"
+    echo "  AVM_CMAKE_OPTS='-DAVM_ENABLE_TRACE_RAISE=1' ./build-fission debug-wasm"
+    exit 1
+}
+
+log() {
+    echo -e "${GREEN}[BUILD]${NC} $1"
+}
+
+warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+    exit 1
+}
+
+print_args() {
+    local args="$*"
+    echo -e "${args// /\\n\\t}"
+}
+
+check_tools() {
+    local missing_tools=()
+
+    if ! command -v cmake &> /dev/null; then
+        missing_tools+=("cmake")
+    fi
+    if ! command -v ninja &> /dev/null; then
+        missing_tools+=("ninja")
+    fi
+    if ! command -v emcmake &> /dev/null; then
+        missing_tools+=("emcmake")
+    fi
+    if ! command -v emmake &> /dev/null; then
+        missing_tools+=("emmake")
+    fi
+
+    # Only log/error if tools are missing
+    if [ ${#missing_tools[@]} -gt 0 ]; then
+        local tools_list=$(IFS=", "; echo "${missing_tools[*]}")
+        error "Missing required tools: $tools_list. Please install them first."
+    fi
+}
+
+build_unix() {
+    local build_type=$1
+    local clean_flag=$2
+    local repo_root="$(pwd)"
+
+    local build_dir="${repo_root}/out/cmake-unix"
+    local cmake_args="-DAVM_BUILD_RUNTIME_ONLY=ON -GNinja"
+    if [[ "${build_type}" = "release" ]]; then
+        cmake_args="${cmake_args} -DCMAKE_BUILD_TYPE=Release -DAVM_RELEASE=ON"
+    else
+        cmake_args="${cmake_args} -DCMAKE_BUILD_TYPE=Debug"
+    fi
+
+    mkdir -p "${build_dir}"
+    pushd "${build_dir}" >/dev/null
+
+    [ "${clean_flag}" ] && (rm CmakeCache.txt || true)
+
+    log "Running cmake for unix with args: \n\t$(print_args ${cmake_args})\nin '$(pwd)'."
+    local cmake_out="$(cmake ${repo_root} ${cmake_args} 2>&1)"
+    [[ $? -ne 0 ]] && error "cmake failed:\n${cmake_out}"
+
+    [ "${clean_flag}" ] && ninja clean
+    ninja AtomVM
+    popd >/dev/null
+
+    cp "${build_dir}/src/AtomVM" out/
+}
+
+build_wasm() {
+    local build_type=$1
+    local clean_flag=$2
+    local repo_root="$(pwd)"
+
+    local build_dir="${repo_root}/out/cmake-wasm"
+    local cmake_args="-DAVM_EMSCRIPTEN_ENV=web -GNinja"
+    if [[ "${build_type}" = "release" ]]; then
+        cmake_args="${cmake_args} -DCMAKE_BUILD_TYPE=Release -DAVM_RELEASE=ON"
+    else
+        cmake_args="${cmake_args} -DCMAKE_BUILD_TYPE=Debug"
+    fi
+
+    mkdir -p "${build_dir}"
+    pushd "${build_dir}" >/dev/null
+
+    [ "${clean_flag}" ] && (rm CmakeCache.txt || true)
+    log "Running cmake for wasm with args: \n\t$(print_args ${cmake_args})\nin '$(pwd)'."
+    local cmake_out="$(emcmake cmake ${repo_root}/src/platforms/emscripten ${cmake_args} 2>&1)"
+    [[ $? -ne 0 ]] && error "emcmake failed:\n${cmake_out}"
+
+    [ "${clean_flag}" ] && ninja clean
+    log "Running 'ninja AtomVM'."
+    emmake ninja AtomVM
+    popd >/dev/null
+
+    log "Compressing."
+    for artifact in "AtomVM.mjs" "AtomVM.wasm"; do
+        [[ ! -f "${build_dir}/src/${artifact}" ]] && error "Required WASM artifact ${artifact} not found in out/"
+        cp "${build_dir}/src/${artifact}" "${repo_root}/out/"
+        gzip -c "${repo_root}/out/${artifact}" > "${repo_root}/out/${artifact}.gz" || error "Failed to compress ${artifact}."
+    done
+}
+
+main() {
+    local CLEAN_FLAG=""
+    local BUILD_MODE=""
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --clean)
+                CLEAN_FLAG="true"
+                shift
+                ;;
+            *)
+                if [[ -z "${BUILD_MODE}" ]]; then
+                    BUILD_MODE=$1
+                    shift
+                else
+                    usage
+                fi
+                ;;
+        esac
+    done
+
+    [[ -z "${BUILD_MODE}" ]] && usage
+
+    # Get script directory and change to project root
+    local SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    cd "${SCRIPT_DIR}"
+
+    check_tools
+    case ${BUILD_MODE} in
+        debug-unix)
+            build_unix "debug" "${CLEAN_FLAG}"
+            ;;
+        release-unix)
+            build_unix "release" "${CLEAN_FLAG}"
+            ;;
+        debug-wasm)
+            build_wasm "debug" "${CLEAN_FLAG}"
+            ;;
+        release-wasm)
+            build_wasm "release" "${CLEAN_FLAG}"
+            ;;
+        *)
+            usage
+            ;;
+    esac
+
+    log "Finished."
+}
+
+main "$@"


### PR DESCRIPTION
Instead of building using command line and cmake/make/emcmake/emmake, streamline to use single script.

```
➜  AtomVM git:(swm) ✗ ./build-fission.sh
Usage: ./build-fission.sh [--clean] <build_mode>
Options:
  --clean       - Clean project before building
Build modes:
  debug-unix    - Debug build for Unix platforms
  debug-wasm    - Debug build for WebAssembly
  release-unix  - Release build for Unix platforms
  release-wasm  - Release build for WebAssembly
```

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
