### PR TITLE
Implement `os:system_time/0`

### DIFF
--- a/libs/estdlib/src/io.erl
+++ b/libs/estdlib/src/io.erl
@@ -27,7 +27,7 @@
 %%-----------------------------------------------------------------------------
 -module(io).
 
--export([format/1, format/2, get_line/1, put_chars/1, put_chars/2, fwrite/2]).
+-export([format/1, format/2, get_line/1, put_chars/1, put_chars/2, fwrite/2, system_time/0]).
 
 %%-----------------------------------------------------------------------------
 %% @doc     Equivalent to format(Format, []).
@@ -111,3 +111,12 @@ put_chars(standard_error, Chars) ->
     put_chars(Chars);
 put_chars(standard_output, Chars) ->
     put_chars(Chars).
+
+%%-----------------------------------------------------------------------------
+%% @returns An integer representing system time.
+%% @doc     Returns the current OS system time in native time unit.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec system_time() -> integer().
+system_time() ->
+    erlang:nif_error(undefined).

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -116,6 +116,7 @@ static term nif_file_native_name_encoding(Context *ctx, int argc, term argv[]);
 static term nif_binary_match(Context *ctx, int argc, term argv[]);
 static term nif_calendar_system_time_to_universal_time_2(Context *ctx, int argc, term argv[]);
 static term nif_os_getenv_1(Context *ctx, int argc, term argv[]);
+static term nif_os_system_time_0(Context *ctx, int argc, term argv[]);
 static term nif_erlang_delete_element_2(Context *ctx, int argc, term argv[]);
 static term nif_erlang_atom_to_binary(Context *ctx, int argc, term argv[]);
 static term nif_erlang_atom_to_list_1(Context *ctx, int argc, term argv[]);
@@ -598,6 +599,12 @@ static const struct Nif system_time_to_universal_time_nif =
 {
     .base.type = NIFFunctionType,
     .nif_ptr = nif_calendar_system_time_to_universal_time_2
+};
+
+static const struct Nif os_system_time_0_nif =
+{
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_os_system_time_0
 };
 
 const struct Nif os_getenv_nif = {
@@ -1743,7 +1750,6 @@ term nif_erlang_monotonic_time_1(Context *ctx, int argc, term argv[])
 
 term nif_erlang_system_time_1(Context *ctx, int argc, term argv[])
 {
-    UNUSED(ctx);
     UNUSED(argc);
 
     struct timespec ts;
@@ -1892,6 +1898,17 @@ term nif_calendar_system_time_to_universal_time_2(Context *ctx, int argc, term a
 
     struct tm broken_down_time;
     return build_datetime_from_tm(ctx, gmtime_r(&ts.tv_sec, &broken_down_time));
+}
+
+term nif_os_system_time_0(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    UNUSED(argv);
+
+    struct timespec ts;
+    sys_time(&ts);
+
+    return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000000ULL + ts.tv_nsec);
 }
 
 static term nif_os_getenv_1(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -47,6 +47,7 @@ binary:bin_to_list/1, &binary_to_list_nif
 binary:list_to_bin/1, &list_to_binary_nif
 calendar:system_time_to_universal_time/2, &system_time_to_universal_time_nif
 os:getenv/1, &os_getenv_nif
+os:system_time/0, &os_system_time_0_nif
 erlang:atom_to_binary/1, &atom_to_binary_nif
 erlang:atom_to_binary/2, &atom_to_binary_nif
 erlang:atom_to_list/1, &atom_to_list_nif

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -113,6 +113,7 @@ compile_erlang(compact23bitsneginteger)
 compile_erlang(negatives2)
 compile_erlang(datetime)
 compile_erlang(test_system_time)
+compile_erlang(test_os_system_time)
 compile_erlang(is_type)
 compile_erlang(is_record)
 compile_erlang(test_bitshift)
@@ -608,6 +609,7 @@ add_custom_target(erlang_test_modules DEPENDS
     negatives2.beam
     datetime.beam
     test_system_time.beam
+    test_os_system_time.beam
     is_type.beam
     test_bitshift.beam
     test_bitwise.beam

--- a/tests/erlang_tests/test_os_system_time.erl
+++ b/tests/erlang_tests/test_os_system_time.erl
@@ -1,0 +1,43 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2018-2023 Davide Bettio <davide@uninstall.it>
+% Copyright 2025 Mateusz Furga <mateusz.furga@swmansion.com>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+-module(test_os_system_time).
+
+-export([start/0]).
+
+start() ->
+    ok = test_os_system_time(1001),
+    ok = test_os_system_time(10),
+    ok = test_os_system_time(1),
+    0.
+
+test_os_system_time(SleepMs) ->
+    After = os:system_time(),
+    sleep(SleepMs),
+    Before = os:system_time(),
+    true = (After < Before),
+    ok.
+
+sleep(Ms) ->
+    receive
+    after Ms ->
+        ok
+    end.

--- a/tests/erlang_tests/test_os_system_time.erl
+++ b/tests/erlang_tests/test_os_system_time.erl
@@ -24,7 +24,7 @@
 -export([start/0]).
 
 start() ->
-    ok = test_os_system_time(1001),
+    ok = test_os_system_time(101),
     ok = test_os_system_time(10),
     ok = test_os_system_time(1),
     0.

--- a/tests/test.c
+++ b/tests/test.c
@@ -164,6 +164,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(negatives2, -500),
     TEST_CASE_EXPECTED(datetime, 3),
     TEST_CASE(test_system_time),
+    TEST_CASE(test_os_system_time),
     TEST_CASE_EXPECTED(is_type, 255),
     TEST_CASE(test_bitshift),
     TEST_CASE_EXPECTED(test_bitwise, -4),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
