### PR TITLE
Fix implementation of `os:system_time/0`

### DIFF
--- a/libs/estdlib/src/io.erl
+++ b/libs/estdlib/src/io.erl
@@ -27,7 +27,7 @@
 %%-----------------------------------------------------------------------------
 -module(io).
 
--export([format/1, format/2, get_line/1, put_chars/1, put_chars/2, fwrite/2, system_time/0]).
+-export([format/1, format/2, get_line/1, put_chars/1, put_chars/2, fwrite/2]).
 
 %%-----------------------------------------------------------------------------
 %% @doc     Equivalent to format(Format, []).
@@ -111,12 +111,3 @@ put_chars(standard_error, Chars) ->
     put_chars(Chars);
 put_chars(standard_output, Chars) ->
     put_chars(Chars).
-
-%%-----------------------------------------------------------------------------
-%% @returns An integer representing system time.
-%% @doc     Returns the current OS system time in native time unit.
-%% @end
-%%-----------------------------------------------------------------------------
--spec system_time() -> integer().
-system_time() ->
-    erlang:nif_error(undefined).

--- a/libs/estdlib/src/os.erl
+++ b/libs/estdlib/src/os.erl
@@ -20,7 +20,7 @@
 %
 -module(os).
 
--export([getenv/1]).
+-export([getenv/1, system_time/0]).
 
 %%-----------------------------------------------------------------------------
 %% @param   Name name of the environment variable
@@ -30,4 +30,13 @@
 %%-----------------------------------------------------------------------------
 -spec getenv(Name :: string()) -> string() | false.
 getenv(_VarName) ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns An integer representing system time.
+%% @doc     Returns the current OS system time in nanoseconds.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec system_time() -> integer().
+system_time() ->
     erlang:nif_error(undefined).

--- a/tests/erlang_tests/test_os_system_time.erl
+++ b/tests/erlang_tests/test_os_system_time.erl
@@ -30,10 +30,10 @@ start() ->
     0.
 
 test_os_system_time(SleepMs) ->
-    After = os:system_time(),
-    sleep(SleepMs),
     Before = os:system_time(),
-    true = (After < Before),
+    sleep(SleepMs),
+    After = os:system_time(),
+    true = (Before < After),
     ok.
 
 sleep(Ms) ->


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
