### PR TITLE
Downstream `io:printable_range/0`

### DIFF
--- a/libs/estdlib/src/io.erl
+++ b/libs/estdlib/src/io.erl
@@ -27,7 +27,16 @@
 %%-----------------------------------------------------------------------------
 -module(io).
 
--export([format/1, format/2, get_line/1, put_chars/1, put_chars/2, fwrite/2]).
+-export([format/1, format/2, get_line/1, put_chars/1, put_chars/2, fwrite/2, printable_range/0]).
+
+%%-----------------------------------------------------------------------------
+%% @doc Returns the user-requested range of printable Unicode characters.
+%% Currently always returns `unicode'
+%% @end
+%%-----------------------------------------------------------------------------
+-spec printable_range() -> unicode | latin1.
+printable_range() ->
+    unicode.
 
 %%-----------------------------------------------------------------------------
 %% @doc     Equivalent to format(Format, []).

--- a/tests/libs/estdlib/test_io_lib.erl
+++ b/tests/libs/estdlib/test_io_lib.erl
@@ -29,6 +29,7 @@
 test() ->
     test_format(),
     test_latin1_char_list(),
+    test_printable_range(),
     ok.
 
 test_format() ->
@@ -254,6 +255,10 @@ test_latin1_char_list() ->
     true = io_lib:latin1_char_list("été"),
     false = io_lib:latin1_char_list(["hello"]),
     false = io_lib:latin1_char_list([$h, $e, $l, $l | $o]),
+    ok.
+
+test_printable_range() ->
+    UnicodeRange = io:printable_range() =:= unicode,
     ok.
 
 id(X) ->


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
