### PR TITLE
Implement `erlang:system_time(native)`

### DIFF
--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -1764,6 +1764,9 @@ term nif_erlang_system_time_1(Context *ctx, int argc, term argv[])
     } else if (argv[0] == MICROSECOND_ATOM) {
         return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000UL + ts.tv_nsec / 1000UL);
 
+    } else if (argv[0] == NATIVE_ATOM) {
+        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000000ULL + ts.tv_nsec);
+
     } else {
         RAISE_ERROR(BADARG_ATOM);
     }

--- a/tests/erlang_tests/test_system_time.erl
+++ b/tests/erlang_tests/test_system_time.erl
@@ -26,6 +26,7 @@ start() ->
     ok = test_system_time(second, 1001),
     ok = test_system_time(millisecond, 10),
     ok = test_system_time(microsecond, 1),
+    ok = test_system_time(native, 1),
 
     ok = expect(fun() -> erlang:system_time(not_a_time_unit) end, badarg),
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
