### PR TITLE
Implement `erlang:system_time/0` nif

### DIFF
--- a/libs/estdlib/src/erlang.erl
+++ b/libs/estdlib/src/erlang.erl
@@ -120,7 +120,8 @@
     localtime/0,
     unique_integer/0,
     unique_integer/1,
-    bump_reductions/1
+    bump_reductions/1,
+    system_time/0
 ]).
 
 -export_type([
@@ -1413,4 +1414,13 @@ module_loaded(_Module) ->
 %%-----------------------------------------------------------------------------
 -spec bump_reductions(pos_integer()) -> true.
 bump_reductions(Reductions) when is_integer(Reductions), Reductions > 1 ->
+    erlang:nif_error(undefined).
+
+%%-----------------------------------------------------------------------------
+%% @returns An integer representing system time.
+%% @doc     Returns the current OS system time in nanoseconds.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec system_time() -> integer().
+system_time() ->
     erlang:nif_error(undefined).

--- a/src/libAtomVM/nifs.c
+++ b/src/libAtomVM/nifs.c
@@ -159,7 +159,7 @@ static term nif_erlang_setelement_3(Context *ctx, int argc, term argv[]);
 static term nif_erlang_spawn_opt(Context *ctx, int argc, term argv[]);
 static term nif_erlang_spawn_fun_opt(Context *ctx, int argc, term argv[]);
 static term nif_erlang_whereis_1(Context *ctx, int argc, term argv[]);
-static term nif_erlang_system_time_1(Context *ctx, int argc, term argv[]);
+static term nif_erlang_system_time(Context *ctx, int argc, term argv[]);
 static term nif_erlang_tuple_to_list_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_list_to_tuple_1(Context *ctx, int argc, term argv[]);
 static term nif_erlang_universaltime_0(Context *ctx, int argc, term argv[]);
@@ -574,7 +574,7 @@ static const struct Nif monotonic_time_nif =
 static const struct Nif system_time_nif =
 {
     .base.type = NIFFunctionType,
-    .nif_ptr = nif_erlang_system_time_1
+    .nif_ptr = nif_erlang_system_time
 };
 
 static const struct Nif universaltime_nif =
@@ -1748,12 +1748,14 @@ term nif_erlang_monotonic_time_1(Context *ctx, int argc, term argv[])
     }
 }
 
-term nif_erlang_system_time_1(Context *ctx, int argc, term argv[])
+term nif_erlang_system_time(Context *ctx, int argc, term argv[])
 {
-    UNUSED(argc);
-
     struct timespec ts;
     sys_time(&ts);
+
+    if (argc == 0) {
+        return make_maybe_boxed_int64(ctx, ((int64_t) ts.tv_sec) * 1000000000ULL + ts.tv_nsec);
+    }
 
     if (argv[0] == SECOND_ATOM) {
         return make_maybe_boxed_int64(ctx, ts.tv_sec);

--- a/src/libAtomVM/nifs.gperf
+++ b/src/libAtomVM/nifs.gperf
@@ -111,6 +111,7 @@ erlang:whereis/1, &whereis_nif
 erlang:++/2, &concat_nif
 erlang:--/2, &erlang_lists_subtract_nif
 erlang:monotonic_time/1, &monotonic_time_nif
+erlang:system_time/0, &system_time_nif
 erlang:system_time/1, &system_time_nif
 erlang:tuple_to_list/1, &tuple_to_list_nif
 erlang:universaltime/0, &universaltime_nif

--- a/tests/erlang_tests/test_system_time.erl
+++ b/tests/erlang_tests/test_system_time.erl
@@ -23,10 +23,13 @@
 -export([start/0]).
 
 start() ->
-    ok = test_system_time(second, 1001),
-    ok = test_system_time(millisecond, 10),
-    ok = test_system_time(microsecond, 1),
-    ok = test_system_time(native, 1),
+    ok = test_system_time(10),
+    ok = test_system_time(1),
+
+    ok = test_system_time_unit(second, 1001),
+    ok = test_system_time_unit(millisecond, 10),
+    ok = test_system_time_unit(microsecond, 1),
+    ok = test_system_time_unit(native, 1),
 
     ok = expect(fun() -> erlang:system_time(not_a_time_unit) end, badarg),
 
@@ -34,7 +37,14 @@ start() ->
 
     0.
 
-test_system_time(Unit, SleepMs) ->
+test_system_time(SleepMs) ->
+    Before = verify_system_time_value(erlang:system_time()),
+    sleep(SleepMs),
+    After = verify_system_time_value(erlang:system_time()),
+    true = (After > Before),
+    ok.
+
+test_system_time_unit(Unit, SleepMs) ->
     Before = verify_system_time_value(erlang:system_time(Unit)),
     sleep(SleepMs),
     After = verify_system_time_value(erlang:system_time(Unit)),


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
