### PR TITLE
Fix `erlang:is_number` BIF

### DIFF
--- a/src/libAtomVM/bif.c
+++ b/src/libAtomVM/bif.c
@@ -271,8 +271,7 @@ term bif_erlang_is_number_1(Context *ctx, uint32_t fail_label, term arg1)
     UNUSED(ctx);
     UNUSED(fail_label);
 
-    //TODO: change to term_is_number
-    return term_is_any_integer(arg1) ? TRUE_ATOM : FALSE_ATOM;
+    return term_is_number(arg1) ? TRUE_ATOM : FALSE_ATOM;
 }
 
 term bif_erlang_is_pid_1(Context *ctx, uint32_t fail_label, term arg1)

--- a/tests/erlang_tests/is_type.erl
+++ b/tests/erlang_tests/is_type.erl
@@ -24,7 +24,7 @@
 
 start() ->
     Pid = self(),
-    test_is_type(hello, <<"hello">>, 10, [1, 2, 3], 5, Pid, make_ref(), {1, 2}).
+    test_is_type(hello, <<"hello">>, 10, [1, 2, 3], 5.5, Pid, make_ref(), {1, 2}).
 
 test_is_type(A, B, I, L, N, P, R, T) ->
     all_true(


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
