### PR TITLE
Add erts_internal:cmp_term/2 nif

### DIFF
--- a/src/libAtomVM/popcorn/popcorn_nifs.c
+++ b/src/libAtomVM/popcorn/popcorn_nifs.c
@@ -510,6 +510,9 @@ static const struct Nif display_string_nif = {
     .nif_ptr = nif_erlang_display_string_2
 };
 
+// The difference from regular term comparison is that this function
+// always compares term type first, which in practice means that
+// an integer is always lesser than a float.
 static term nif_erts_internal_cmp_term(Context *ctx, int argc, term argv[])
 {
     UNUSED(argc);
@@ -521,6 +524,10 @@ static term nif_erts_internal_cmp_term(Context *ctx, int argc, term argv[])
             return term_from_int4(1);
         case TermLessThan:
             return term_from_int4(-1);
+        case TermCompareMemoryAllocFail:
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        default:
+            AVM_ABORT();
     }
 }
 

--- a/src/libAtomVM/popcorn/popcorn_nifs.c
+++ b/src/libAtomVM/popcorn/popcorn_nifs.c
@@ -510,6 +510,25 @@ static const struct Nif display_string_nif = {
     .nif_ptr = nif_erlang_display_string_2
 };
 
+static term nif_erts_internal_cmp_term(Context *ctx, int argc, term argv[])
+{
+    UNUSED(argc);
+    TermCompareResult result = term_compare(argv[0], argv[1], TermCompareExact, ctx->global);
+    switch (result) {
+        case TermEquals:
+            return term_from_int4(0);
+        case TermGreaterThan:
+            return term_from_int4(1);
+        case TermLessThan:
+            return term_from_int4(-1);
+    }
+}
+
+static const struct Nif erts_internal_cmp_term_nif = {
+    .base.type = NIFFunctionType,
+    .nif_ptr = nif_erts_internal_cmp_term
+};
+
 // ETS
 
 static term nif_ets_new(Context *ctx, int argc, term argv[])

--- a/src/libAtomVM/popcorn/popcorn_nifs.gperf
+++ b/src/libAtomVM/popcorn/popcorn_nifs.gperf
@@ -26,6 +26,8 @@ erlang:list_to_bitstring/1, &list_to_bitstring_nif
 #
 avm_rand:splitmix64_next/1, &rand_splitmix64_next_nif
 #
+erts_internal:cmp_term/2, &erts_internal_cmp_term_nif
+#
 erlang:md5/1, &md5_nif
 #
 # ETS


### PR DESCRIPTION
fixes https://github.com/software-mansion/popcorn/issues/277

The difference from regular term comparison is that `erts_internal:cmp_term` always compares term type first, which in practice means that an integer is always lesser than a float.