### PR TITLE
Implement ETS `delete/1` and `delete_object/2`

### DIFF
--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -228,6 +228,7 @@ Popcorn2EtsStatus popcorn2_ets_lookup(term name_or_ref, term key, term *ret, Con
     Popcorn2EtsStatus result = lookup_project(table, key, ETS_WHOLE_TUPLE, ret, ctx);
 
     SMP_UNLOCK(table);
+
     return result;
 }
 
@@ -248,6 +249,7 @@ Popcorn2EtsStatus popcorn2_ets_lookup_element(term name_or_ref, term key, size_t
     Popcorn2EtsStatus result = lookup_project(table, key, index, ret, ctx);
 
     SMP_UNLOCK(table);
+
     return result;
 }
 
@@ -264,9 +266,62 @@ Popcorn2EtsStatus popcorn2_ets_delete(term name_or_ref, term key, Context *ctx)
     }
 
     (void) ets_multimap_remove(table->multimap, key, ctx->global);
+
     SMP_UNLOCK(table);
 
     return Popcorn2EtsOk;
+}
+
+Popcorn2EtsStatus popcorn2_ets_delete_table(term name_or_ref, Context *ctx)
+{
+    struct Popcorn2EtsTable *table = get_table(
+        &ctx->global->popcorn2_ets,
+        name_or_ref,
+        ctx->process_id,
+        TableAccessWrite);
+
+    if (table == NULL) {
+        return Popcorn2EtsBadAccess;
+    }
+
+    synclist_wrlock(&ctx->global->popcorn2_ets.ets_tables);
+
+    list_remove(&table->head);
+
+    SMP_UNLOCK(table);
+    table_destroy(table, ctx->global);
+
+    synclist_unlock(&ctx->global->popcorn2_ets.ets_tables);
+
+    return Popcorn2EtsOk;
+}
+
+Popcorn2EtsStatus popcorn2_ets_delete_object(term name_or_ref, term tuple, Context *ctx)
+{
+    struct Popcorn2EtsTable *table = get_table(
+        &ctx->global->popcorn2_ets,
+        name_or_ref,
+        ctx->process_id,
+        TableAccessWrite);
+
+    if (table == NULL) {
+        return Popcorn2EtsBadAccess;
+    }
+
+    EtsMultimapStatus result = ets_multimap_remove_tuple(table->multimap, tuple, ctx->global);
+
+    SMP_UNLOCK(table);
+
+    switch (result) {
+        case EtsMultimapOk:
+            return Popcorn2EtsOk;
+        case EtsMultimapBadTuple:
+            return Popcorn2EtsBadEntry;
+        case EtsMultimapAllocationError:
+            return Popcorn2EtsAllocationError;
+        default:
+            UNREACHABLE();
+    }
 }
 
 void popcorn2_ets_delete_owned_tables(Popcorn2Ets *ets, int32_t process_id, GlobalContext *global)

--- a/src/libAtomVM/popcorn/popcorn_ets2.h
+++ b/src/libAtomVM/popcorn/popcorn_ets2.h
@@ -83,6 +83,8 @@ Popcorn2EtsStatus popcorn2_ets_insert(term name_or_ref, term entry, bool new, Co
 Popcorn2EtsStatus popcorn2_ets_lookup(term name_or_ref, term key, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_lookup_element(term name_or_ref, term key, size_t index, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete(term name_or_ref, term key, Context *ctx);
+Popcorn2EtsStatus popcorn2_ets_delete_table(term name_or_ref, Context *ctx);
+Popcorn2EtsStatus popcorn2_ets_delete_object(term name_or_ref, term tuple, Context *ctx);
 
 #ifdef __cplusplus
 }

--- a/src/libAtomVM/popcorn/popcorn_ets_multimap.c
+++ b/src/libAtomVM/popcorn/popcorn_ets_multimap.c
@@ -24,6 +24,9 @@
 #include "popcorn_ets_multimap.h"
 #include "popcorn_ets_multimap_hash.h"
 
+#define DYNARRAY_INITIAL_CAPACITY 8
+#define DYNARRAY_GROWTH_FACTOR 2
+
 static EtsMultimapEntry *entry_new(term tuple);
 static void entry_delete(EtsMultimapEntry *entry, GlobalContext *global);
 static EtsMultimapNode *node_new(EtsMultimapNode *next, EtsMultimapEntry *entries);
@@ -273,7 +276,7 @@ EtsMultimapStatus ets_multimap_remove_tuple(
 
     assert(node->entries != NULL);
 
-    size_t capacity = 8;
+    size_t capacity = DYNARRAY_INITIAL_CAPACITY;
     size_t count = 0;
 
     EtsMultimapEntry **to_remove = malloc(sizeof(EtsMultimapEntry *) * capacity);
@@ -284,14 +287,14 @@ EtsMultimapStatus ets_multimap_remove_tuple(
     for (EtsMultimapEntry *iter = node->entries; iter != NULL; iter = iter->next) {
         TermCompareResult result = term_compare(tuple, iter->tuple, TermCompareExact, global);
 
-        if (result == TermCompareMemoryAllocFail) {
+        if (UNLIKELY(result == TermCompareMemoryAllocFail)) {
             free(to_remove);
             return EtsMultimapAllocationError;
         }
 
         if (result == TermEquals) {
             if (count >= capacity) {
-                capacity *= 2;
+                capacity *= DYNARRAY_GROWTH_FACTOR;
                 EtsMultimapEntry **new_to_remove = realloc(to_remove, sizeof(EtsMultimapEntry *) * capacity);
                 if (IS_NULL_PTR(new_to_remove)) {
                     free(to_remove);

--- a/src/libAtomVM/popcorn/popcorn_ets_multimap.c
+++ b/src/libAtomVM/popcorn/popcorn_ets_multimap.c
@@ -249,6 +249,100 @@ EtsMultimapStatus ets_multimap_remove(
     return EtsMultimapOk;
 }
 
+EtsMultimapStatus ets_multimap_remove_tuple(
+    EtsMultimap *multimap,
+    term tuple,
+    GlobalContext *global)
+{
+    assert(term_is_tuple(tuple));
+
+    if (multimap->key_index >= (size_t) term_get_tuple_arity(tuple)) {
+        return EtsMultimapBadTuple;
+    }
+
+    term key = term_get_tuple_element(tuple, multimap->key_index);
+
+    EtsMultimapNode *node;
+    if (UNLIKELY(node_find(multimap, key, &node, global) == EtsMultimapAllocationError)) {
+        return EtsMultimapAllocationError;
+    }
+
+    if (node == NULL) {
+        return EtsMultimapOk;
+    }
+
+    assert(node->entries != NULL);
+
+    size_t capacity = 8;
+    size_t count = 0;
+
+    EtsMultimapEntry **to_remove = malloc(sizeof(EtsMultimapEntry *) * capacity);
+    if (IS_NULL_PTR(to_remove)) {
+        return EtsMultimapAllocationError;
+    }
+
+    for (EtsMultimapEntry *iter = node->entries; iter != NULL; iter = iter->next) {
+        TermCompareResult result = term_compare(tuple, iter->tuple, TermCompareExact, global);
+
+        if (result == TermCompareMemoryAllocFail) {
+            free(to_remove);
+            return EtsMultimapAllocationError;
+        }
+
+        if (result == TermEquals) {
+            if (count >= capacity) {
+                capacity *= 2;
+                EtsMultimapEntry **new_to_remove = realloc(to_remove, sizeof(EtsMultimapEntry *) * capacity);
+                if (IS_NULL_PTR(new_to_remove)) {
+                    free(to_remove);
+                    return EtsMultimapAllocationError;
+                }
+                to_remove = new_to_remove;
+            }
+            to_remove[count++] = iter;
+        }
+    }
+
+    EtsMultimapEntry *prev = NULL;
+    for (EtsMultimapEntry *iter = node->entries; iter != NULL; prev = iter, iter = iter->next) {
+        for (size_t i = 0; i < count; i++) {
+            if (iter == to_remove[i]) {
+                if (prev == NULL) {
+                    node->entries = iter->next;
+                } else {
+                    prev->next = iter->next;
+                }
+            }
+        }
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        entry_delete(to_remove[i], global);
+    }
+
+    if (node->entries == NULL) {
+        uint32_t idx = hash_term(key, global) % NUM_BUCKETS;
+
+        EtsMultimapNode *prev = NULL;
+        for (EtsMultimapNode *iter = multimap->buckets[idx]; iter != NULL; prev = iter, iter = iter->next) {
+            if (iter == node) {
+                if (prev == NULL) {
+                    multimap->buckets[idx] = iter->next;
+                } else {
+                    prev->next = iter->next;
+                }
+                break;
+            }
+        }
+
+        node_delete(node, global);
+    }
+
+    free(to_remove);
+
+    return EtsMultimapOk;
+}
+
 static EtsMultimapStatus node_find(
     EtsMultimap *multimap,
     term key,

--- a/src/libAtomVM/popcorn/popcorn_ets_multimap.h
+++ b/src/libAtomVM/popcorn/popcorn_ets_multimap.h
@@ -41,6 +41,7 @@ typedef enum EtsMultimapStatus
 {
     EtsMultimapOk,
     EtsMultimapKeyExists,
+    EtsMultimapBadTuple,
     EtsMultimapAllocationError
 } EtsMultimapStatus;
 
@@ -132,6 +133,19 @@ EtsMultimapStatus ets_multimap_lookup(
 EtsMultimapStatus ets_multimap_remove(
     EtsMultimap *multimap,
     term key,
+    GlobalContext *global);
+
+/**
+ * @brief Remove a given tuple from the multimap.
+ *
+ * @param multimap the multimap
+ * @param tuple the tuple to remove
+ * @param global the global context
+ * @return EtsMultimapOk on success, otherwise an error status
+ */
+EtsMultimapStatus ets_multimap_remove_tuple(
+    EtsMultimap *multimap,
+    term tuple,
     GlobalContext *global);
 
 #ifdef __cplusplus

--- a/src/libAtomVM/popcorn/popcorn_nifs.c
+++ b/src/libAtomVM/popcorn/popcorn_nifs.c
@@ -838,13 +838,10 @@ static term nif_ets_delete(Context *ctx, int argc, term argv[])
 
     Popcorn2EtsStatus result;
 
-    if (argc == 2) {
-        result = popcorn2_ets_delete(name_or_ref, argv[1], ctx);
+    if (argc == 1) {
+        result = popcorn2_ets_delete_table(name_or_ref, ctx);
     } else {
-        term ret = TRUE_ATOM;
-        result = Popcorn2EtsOk;
-        // TODO
-        // result = popcorn_ets_drop_table(name_or_ref, &ret, ctx);
+        result = popcorn2_ets_delete(name_or_ref, argv[1], ctx);
     }
 
     switch (result) {
@@ -860,25 +857,26 @@ static term nif_ets_delete(Context *ctx, int argc, term argv[])
 
 static term nif_ets_delete_object(Context *ctx, int argc, term argv[])
 {
-    UNUSED(argc);
+    assert(argc == 2);
 
-    term ref = argv[0];
-    VALIDATE_VALUE(ref, is_ets_table_id);
-
+    term name_or_ref = argv[0];
     term tuple = argv[1];
+
+    VALIDATE_VALUE(name_or_ref, is_ets_table_id);
     VALIDATE_VALUE(tuple, term_is_tuple);
 
-    term ret = term_invalid_term();
-    PopcornEtsErrorCode result = popcorn_ets_delete_object(ref, tuple, &ret, ctx);
+    Popcorn2EtsStatus result = popcorn2_ets_delete_object(name_or_ref, tuple, ctx);
+
     switch (result) {
-        case PopcornEtsOk:
-            return ret;
-        case PopcornEtsBadAccess:
-        case PopcornEtsBadPosition:
+        case Popcorn2EtsOk:
+            return TRUE_ATOM;
+        case Popcorn2EtsBadAccess:
+        case Popcorn2EtsBadEntry:
             RAISE_ERROR(BADARG_ATOM);
-        case PopcornEtsAllocationFailure:
+        case Popcorn2EtsAllocationError:
             RAISE_ERROR(MEMORY_ATOM);
         default:
+            // unreachable
             AVM_ABORT();
     }
 }

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -34,6 +34,7 @@ start() ->
     ok = isolated(fun test_insert_new_bag/0),
     ok = isolated(fun test_insert_new_duplicate_bag/0),
     ok = isolated(fun test_delete/0),
+    ok = isolated(fun test_delete_object/0),
     ok = isolated(fun test_lookup_element/0),
     % ok = isolated(fun test_update_counter/0),
     0.
@@ -333,29 +334,115 @@ test_insert_new_duplicate_bag() ->
     ok.
 
 test_delete() ->
-    T = ets:new(test, []),
+    % set
+    S = ets:new(test, [set]),
+    true = ets:delete(S, key_not_exist),
+    true = ets:insert(S, [{key, value}, {key2, value2}]),
 
-    % Not existing
-    true = ets:delete(T, key),
-    [] = ets:lookup(T, key),
+    true = ets:delete(S, key),
+    [] = ets:lookup(S, key),
+    [{key2, value2}] = ets:lookup(S, key2),
 
-    % Keep key2
-    true = ets:insert(T, {key, value}),
-    true = ets:insert(T, {key2, value2}),
-    [{key, value}] = ets:lookup(T, key),
-    true = ets:delete(T, key),
-    [] = ets:lookup(T, key),
-    [{key2, value2}] = ets:lookup(T, key2),
+    true = ets:delete(S, key2),
+    [] = ets:lookup(S, key2),
+    true = ets:delete(S, key2),
 
-    % Re-add key
-    true = ets:insert(T, {key, new_value}),
-    [{key, new_value}] = ets:lookup(T, key),
+    true = ets:delete(S),
 
-    % Drop entire table
-    % true = ets:delete(T),
-    % assert_badarg(fun() -> ets:lookup(T, key) end),
-    % assert_badarg(fun() -> ets:delete(T) end),
-    % assert_badarg(fun() -> ets:delete(none) end),
+    % bag
+    B = ets:new(test, [bag]),
+    true = ets:delete(B, key_not_exist),
+    true = ets:insert(B, [{key, value}, {key, value2}, {key2, value3}]),
+
+    true = ets:delete(B, key),
+    [] = ets:lookup(B, key),
+    [{key2, value3}] = ets:lookup(B, key2),
+
+    true = ets:delete(B, key2),
+    [] = ets:lookup(B, key2),
+    true = ets:delete(B, key2),
+
+    true = ets:delete(B),
+
+    % duplicate_bag
+    DB = ets:new(test, [duplicate_bag]),
+    true = ets:delete(DB, key_not_exist),
+    true = ets:insert(DB, [{key, value}, {key, value}, {key2, value2}]),
+
+    true = ets:delete(DB, key),
+    [] = ets:lookup(DB, key),
+    [{key2, value2}] = ets:lookup(DB, key2),
+
+    true = ets:delete(DB, key2),
+    [] = ets:lookup(DB, key2),
+    true = ets:delete(DB, key2),
+
+    true = ets:delete(DB),
+
+    % badargs
+    TErr = ets:new(test, [{keypos, 2}]),
+    true = ets:delete(TErr),
+    assert_badarg(fun() -> ets:lookup(TErr, key) end),
+    assert_badarg(fun() -> ets:delete(TErr) end),
+    assert_badarg(fun() -> ets:delete(bad_table) end),
+    ok.
+
+test_delete_object() ->
+    % set
+    S = ets:new(test, [set]),
+    true = ets:insert(S, [{key, value}, {key2, value2}]),
+
+    true = ets:delete_object(S, {key_not_exist, value_not_exist}),
+    [{key, value}] = ets:lookup(S, key),
+    [{key2, value2}] = ets:lookup(S, key2),
+
+    true = ets:delete_object(S, {key, value}),
+    [] = ets:lookup(S, key),
+    [{key2, value2}] = ets:lookup(S, key2),
+
+    true = ets:delete_object(S, {key2, value_not_exist}),
+    [{key2, value2}] = ets:lookup(S, key2),
+
+    true = ets:delete_object(S, {key2, value2}),
+    [] = ets:lookup(S, key2),
+
+    % bag
+    B = ets:new(test, [bag]),
+    true = ets:insert(B, [{key, value}, {key, value2}, {key2, value2}]),
+
+    true = ets:delete_object(B, {key, value2}),
+    [{key, value}] = ets:lookup(B, key),
+
+    true = ets:delete_object(B, {key, value_not_exist}),
+    [{key, value}] = ets:lookup(B, key),
+
+    true = ets:delete_object(B, {key, value}),
+    [] = ets:lookup(B, key),
+
+    [{key2, value2}] = ets:lookup(B, key2),
+    true = ets:delete_object(B, {key2, value2}),
+    [] = ets:lookup(B, key2),
+
+    % duplicate_bag
+    DB = ets:new(test, [duplicate_bag]),
+    true = ets:insert(DB, [{key, value}, {key, value2}, {key, value}]),
+
+    true = ets:delete_object(DB, {key, value}),
+    [{key, value2}] = ets:lookup(DB, key),
+
+    true = ets:delete_object(DB, {key, value_not_exist}),
+    [{key, value2}] = ets:lookup(DB, key),
+
+    true = ets:delete_object(DB, {key, value2}),
+    [] = ets:lookup(DB, key2),
+
+    % badargs
+    TErr = ets:new(test, [{keypos, 2}]),
+    assert_badarg(fun() -> ets:delete_object(TErr, not_a_tuple) end),
+    assert_badarg(fun() -> ets:delete_object(TErr, [{key, value}, {key, value2}]) end),
+    assert_badarg(fun() -> ets:delete_object(TErr, {}) end),
+    assert_badarg(fun() -> ets:delete_object(TErr, {bad_keypos}) end),
+    assert_badarg(fun() -> ets:delete_object(bad_table, {key, value}) end),
     ok.
 
 test_lookup_element() ->


### PR DESCRIPTION
This PR implements the `delete/1` and `delete_object/2` functions.