### PR TITLE
Implement ETS `take/2`

### DIFF
--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -276,7 +276,7 @@ Popcorn2EtsStatus popcorn2_ets_update_element(
 
     term *tuple = NULL;
     size_t count;
-    EtsMultimapStatus status = ets_multimap_lookup(table->multimap, key, &tuple, &count, ctx->global);
+    Popcorn2EtsStatus status = ets_multimap_lookup(table->multimap, key, &tuple, &count, ctx->global);
 
     bool insert_default = (count == 0);
 
@@ -331,14 +331,7 @@ Popcorn2EtsStatus popcorn2_ets_update_element(
 
     SMP_UNLOCK(table);
 
-    switch (status) {
-        case EtsMultimapOk:
-            return Popcorn2EtsOk;
-        case EtsMultimapAllocationError:
-            return Popcorn2EtsAllocationError;
-        default:
-            UNREACHABLE();
-    }
+    return status;
 }
 
 Popcorn2EtsStatus popcorn2_ets_delete(term name_or_ref, term key, Context *ctx)
@@ -353,20 +346,7 @@ Popcorn2EtsStatus popcorn2_ets_delete(term name_or_ref, term key, Context *ctx)
         return Popcorn2EtsBadAccess;
     }
 
-    Popcorn2EtsStatus result = Popcorn2EtsOk;
-
-    EtsMultimapStatus status = ets_multimap_remove(table->multimap, key, ctx->global);
-
-    switch (status) {
-        case EtsMultimapOk:
-            result = Popcorn2EtsOk;
-            break;
-        case EtsMultimapAllocationError:
-            result = Popcorn2EtsAllocationError;
-            break;
-        default:
-            UNREACHABLE();
-    }
+    Popcorn2EtsStatus result = ets_multimap_remove(table->multimap, key, ctx->global);
 
     SMP_UNLOCK(table);
 
@@ -409,20 +389,11 @@ Popcorn2EtsStatus popcorn2_ets_delete_object(term name_or_ref, term tuple, Conte
         return Popcorn2EtsBadAccess;
     }
 
-    EtsMultimapStatus result = ets_multimap_remove_tuple(table->multimap, tuple, ctx->global);
+    Popcorn2EtsStatus result = ets_multimap_remove_tuple(table->multimap, tuple, ctx->global);
 
     SMP_UNLOCK(table);
 
-    switch (result) {
-        case EtsMultimapOk:
-            return Popcorn2EtsOk;
-        case EtsMultimapBadTuple:
-            return Popcorn2EtsBadEntry;
-        case EtsMultimapAllocationError:
-            return Popcorn2EtsAllocationError;
-        default:
-            UNREACHABLE();
-    }
+    return result;
 }
 
 void popcorn2_ets_delete_owned_tables(Popcorn2Ets *ets, int32_t process_id, GlobalContext *global)
@@ -529,7 +500,7 @@ static Popcorn2EtsStatus insert_one(
 {
     assert(term_is_tuple(tuple));
 
-    EtsMultimapStatus result = EtsMultimapOk;
+    Popcorn2EtsStatus result = Popcorn2EtsOk;
 
     if (table->key_index >= (size_t) term_get_tuple_arity(tuple)) {
         return Popcorn2EtsBadEntry;
@@ -539,7 +510,7 @@ static Popcorn2EtsStatus insert_one(
         term key = term_get_tuple_element(tuple, table->key_index);
         size_t existing = 0;
         result = ets_multimap_lookup(table->multimap, key, NULL, &existing, ctx->global);
-        if (UNLIKELY(result == EtsMultimapAllocationError)) {
+        if (UNLIKELY(result == Popcorn2EtsAllocationError)) {
             return Popcorn2EtsAllocationError;
         }
         if (existing > 0) {
@@ -549,16 +520,7 @@ static Popcorn2EtsStatus insert_one(
 
     result = ets_multimap_insert(table->multimap, &tuple, 1, ctx->global);
 
-    switch (result) {
-        case EtsMultimapOk:
-            return Popcorn2EtsOk;
-        case EtsMultimapAllocationError:
-            return Popcorn2EtsAllocationError;
-        case EtsMultimapKeyExists:
-            return Popcorn2EtsKeyExists;
-        default:
-            UNREACHABLE();
-    }
+    return result;
 }
 
 static Popcorn2EtsStatus insert_many(
@@ -569,7 +531,7 @@ static Popcorn2EtsStatus insert_many(
 {
     assert(term_is_list(tuples));
 
-    EtsMultimapStatus result = EtsMultimapOk;
+    Popcorn2EtsStatus result = Popcorn2EtsOk;
 
     size_t count = 0;
     for (term iter = tuples; !term_is_nil(iter); iter = term_get_list_tail(iter), count++) {
@@ -587,7 +549,7 @@ static Popcorn2EtsStatus insert_many(
             term key = term_get_tuple_element(tuple, table->key_index);
             size_t existing = 0;
             result = ets_multimap_lookup(table->multimap, key, NULL, &existing, ctx->global);
-            if (UNLIKELY(result == EtsMultimapAllocationError)) {
+            if (UNLIKELY(result == Popcorn2EtsAllocationError)) {
                 return Popcorn2EtsAllocationError;
             }
             if (existing > 0) {
@@ -610,16 +572,7 @@ static Popcorn2EtsStatus insert_many(
 
     free(to_insert);
 
-    switch (result) {
-        case EtsMultimapOk:
-            return Popcorn2EtsOk;
-        case EtsMultimapAllocationError:
-            return Popcorn2EtsAllocationError;
-        case EtsMultimapKeyExists:
-            return Popcorn2EtsKeyExists;
-        default:
-            UNREACHABLE();
-    }
+    return result;
 }
 
 static Popcorn2EtsStatus lookup_select(
@@ -636,8 +589,8 @@ static Popcorn2EtsStatus lookup_select(
     term *tuples = NULL;
 
     size_t count;
-    EtsMultimapStatus result = ets_multimap_lookup(table->multimap, key, &tuples, &count, ctx->global);
-    if (UNLIKELY(result == EtsMultimapAllocationError)) {
+    Popcorn2EtsStatus result = ets_multimap_lookup(table->multimap, key, &tuples, &count, ctx->global);
+    if (UNLIKELY(result == Popcorn2EtsAllocationError)) {
         return Popcorn2EtsAllocationError;
     }
 

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -334,6 +334,29 @@ Popcorn2EtsStatus popcorn2_ets_update_element(
     return status;
 }
 
+Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Context *ctx)
+{
+    struct Popcorn2EtsTable *table = get_table(
+        &ctx->global->popcorn2_ets,
+        name_or_ref,
+        ctx->process_id,
+        TableAccessWrite);
+
+    if (table == NULL) {
+        return Popcorn2EtsBadAccess;
+    }
+
+    Popcorn2EtsStatus result = lookup_select(table, key, ETS_WHOLE_TUPLE, ret, ctx);
+
+    if (result == Popcorn2EtsOk) {
+        result = ets_multimap_remove(table->multimap, key, ctx->global);
+    }
+
+    SMP_UNLOCK(table);
+
+    return result;
+}
+
 Popcorn2EtsStatus popcorn2_ets_delete(term name_or_ref, term key, Context *ctx)
 {
     struct Popcorn2EtsTable *table = get_table(

--- a/src/libAtomVM/popcorn/popcorn_ets2.h
+++ b/src/libAtomVM/popcorn/popcorn_ets2.h
@@ -87,6 +87,7 @@ Popcorn2EtsStatus popcorn2_ets_update_element(term name_or_ref, term key, term e
 Popcorn2EtsStatus popcorn2_ets_delete(term name_or_ref, term key, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete_table(term name_or_ref, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete_object(term name_or_ref, term tuple, Context *ctx);
+Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Context *ctx);
 
 #ifdef __cplusplus
 }

--- a/src/libAtomVM/popcorn/popcorn_ets2.h
+++ b/src/libAtomVM/popcorn/popcorn_ets2.h
@@ -84,10 +84,10 @@ Popcorn2EtsStatus popcorn2_ets_lookup(term name_or_ref, term key, term *ret, Con
 Popcorn2EtsStatus popcorn2_ets_lookup_element(term name_or_ref, term key, size_t index, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_insert(term name_or_ref, term entry, bool new, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_update_element(term name_or_ref, term key, term element_spec, term default_tuple, Context *ctx);
+Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete(term name_or_ref, term key, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete_table(term name_or_ref, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete_object(term name_or_ref, term tuple, Context *ctx);
-Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Context *ctx);
 
 #ifdef __cplusplus
 }

--- a/src/libAtomVM/popcorn/popcorn_ets_multimap.c
+++ b/src/libAtomVM/popcorn/popcorn_ets_multimap.c
@@ -33,7 +33,7 @@ static EtsMultimapEntry *entry_new(term tuple);
 static void entry_delete(EtsMultimapEntry *entry, GlobalContext *global);
 static EtsMultimapNode *node_new(EtsMultimapNode *next, EtsMultimapEntry *entries);
 static void node_delete(EtsMultimapNode *node, GlobalContext *global);
-static EtsMultimapStatus node_find(
+static Popcorn2EtsStatus node_find(
     EtsMultimap *multimap,
     term key,
     EtsMultimapNode **out_node,
@@ -45,7 +45,7 @@ static void insert_revert(
     EtsMultimapEntry **entries,
     size_t count,
     GlobalContext *global);
-static EtsMultimapStatus tuple_exists(
+static Popcorn2EtsStatus tuple_exists(
     EtsMultimapNode *node,
     term tuple,
     bool *exists,
@@ -81,7 +81,7 @@ void ets_multimap_delete(EtsMultimap *multimap, GlobalContext *global)
     free(multimap);
 }
 
-EtsMultimapStatus ets_multimap_lookup(
+Popcorn2EtsStatus ets_multimap_lookup(
     EtsMultimap *multimap,
     term key,
     term **tuples,
@@ -93,13 +93,13 @@ EtsMultimapStatus ets_multimap_lookup(
     *count = 0;
 
     EtsMultimapNode *node;
-    EtsMultimapStatus result = node_find(multimap, key, &node, global);
-    if (UNLIKELY(result == EtsMultimapAllocationError)) {
+    Popcorn2EtsStatus result = node_find(multimap, key, &node, global);
+    if (UNLIKELY(result == Popcorn2EtsAllocationError)) {
         return result;
     }
 
     if (node == NULL) {
-        return EtsMultimapOk;
+        return Popcorn2EtsOk;
     }
 
     assert(node->entries != NULL);
@@ -110,17 +110,17 @@ EtsMultimapStatus ets_multimap_lookup(
 
     if (tuples == NULL) {
         // only return number of tuples found
-        return EtsMultimapOk;
+        return Popcorn2EtsOk;
     }
 
     if (*count == 0) {
         *tuples = NULL;
-        return EtsMultimapOk;
+        return Popcorn2EtsOk;
     }
 
     *tuples = malloc(sizeof(term) * (*count));
     if (IS_NULL_PTR(*tuples)) {
-        return EtsMultimapAllocationError;
+        return Popcorn2EtsAllocationError;
     }
 
     size_t i = 0;
@@ -129,22 +129,22 @@ EtsMultimapStatus ets_multimap_lookup(
         (*tuples)[i] = iter->tuple;
     }
 
-    return EtsMultimapOk;
+    return Popcorn2EtsOk;
 }
 
-EtsMultimapStatus ets_multimap_insert(
+Popcorn2EtsStatus ets_multimap_insert(
     EtsMultimap *multimap,
     term *tuples,
     size_t count,
     GlobalContext *global)
 {
     if (tuples == NULL || count == 0) {
-        return EtsMultimapOk;
+        return Popcorn2EtsOk;
     }
 
     EtsMultimapEntry **entries = malloc(sizeof(EtsMultimapEntry *) * count);
     if (IS_NULL_PTR(entries)) {
-        return EtsMultimapAllocationError;
+        return Popcorn2EtsAllocationError;
     }
 
     for (size_t i = 0; i < count; i++) {
@@ -154,26 +154,26 @@ EtsMultimapStatus ets_multimap_insert(
                 entry_delete(entries[j], global);
             }
             free(entries);
-            return EtsMultimapAllocationError;
+            return Popcorn2EtsAllocationError;
         }
     }
 
-    EtsMultimapStatus status = EtsMultimapOk;
+    Popcorn2EtsStatus status = Popcorn2EtsOk;
 
     for (size_t i = 0; i < count; i++) {
         EtsMultimapEntry *entry = entries[i];
         term key = term_get_tuple_element(entry->tuple, multimap->key_index);
 
         EtsMultimapNode *node;
-        if (UNLIKELY(node_find(multimap, key, &node, global) == EtsMultimapAllocationError)) {
-            status = EtsMultimapAllocationError;
+        if (UNLIKELY(node_find(multimap, key, &node, global) == Popcorn2EtsAllocationError)) {
+            status = Popcorn2EtsAllocationError;
             break;
         }
 
         if (node == NULL) {
             EtsMultimapNode *new_node = node_new(NULL, entry);
             if (IS_NULL_PTR(new_node)) {
-                status = EtsMultimapAllocationError;
+                status = Popcorn2EtsAllocationError;
                 break;
             }
 
@@ -190,8 +190,8 @@ EtsMultimapStatus ets_multimap_insert(
         if (multimap->type == EtsMultimapTypeSet) {
             bool exists;
 
-            if (UNLIKELY(tuple_exists(node, entry->tuple, &exists, global) == EtsMultimapAllocationError)) {
-                status = EtsMultimapAllocationError;
+            if (UNLIKELY(tuple_exists(node, entry->tuple, &exists, global) == Popcorn2EtsAllocationError)) {
+                status = Popcorn2EtsAllocationError;
                 break;
             }
 
@@ -204,7 +204,7 @@ EtsMultimapStatus ets_multimap_insert(
         node->entries = entry;
     }
 
-    if (status != EtsMultimapOk) {
+    if (status != Popcorn2EtsOk) {
         insert_revert(multimap, entries, count, global);
     } else if (multimap->type == EtsMultimapTypeSingle) {
         multimap_to_single(multimap, global);
@@ -215,18 +215,18 @@ EtsMultimapStatus ets_multimap_insert(
     return status;
 }
 
-EtsMultimapStatus ets_multimap_remove(
+Popcorn2EtsStatus ets_multimap_remove(
     EtsMultimap *multimap,
     term key,
     GlobalContext *global)
 {
     EtsMultimapNode *node;
-    if (UNLIKELY(node_find(multimap, key, &node, global) == EtsMultimapAllocationError)) {
-        return EtsMultimapAllocationError;
+    if (UNLIKELY(node_find(multimap, key, &node, global) == Popcorn2EtsAllocationError)) {
+        return Popcorn2EtsAllocationError;
     }
 
     if (node == NULL) {
-        return EtsMultimapOk;
+        return Popcorn2EtsOk;
     }
 
     assert(node->entries != NULL);
@@ -251,10 +251,10 @@ EtsMultimapStatus ets_multimap_remove(
 
     node_delete(node, global);
 
-    return EtsMultimapOk;
+    return Popcorn2EtsOk;
 }
 
-EtsMultimapStatus ets_multimap_remove_tuple(
+Popcorn2EtsStatus ets_multimap_remove_tuple(
     EtsMultimap *multimap,
     term tuple,
     GlobalContext *global)
@@ -262,18 +262,18 @@ EtsMultimapStatus ets_multimap_remove_tuple(
     assert(term_is_tuple(tuple));
 
     if (multimap->key_index >= (size_t) term_get_tuple_arity(tuple)) {
-        return EtsMultimapBadTuple;
+        return Popcorn2EtsBadEntry;
     }
 
     term key = term_get_tuple_element(tuple, multimap->key_index);
 
     EtsMultimapNode *node;
-    if (UNLIKELY(node_find(multimap, key, &node, global) == EtsMultimapAllocationError)) {
-        return EtsMultimapAllocationError;
+    if (UNLIKELY(node_find(multimap, key, &node, global) == Popcorn2EtsAllocationError)) {
+        return Popcorn2EtsAllocationError;
     }
 
     if (node == NULL) {
-        return EtsMultimapOk;
+        return Popcorn2EtsOk;
     }
 
     assert(node->entries != NULL);
@@ -283,7 +283,7 @@ EtsMultimapStatus ets_multimap_remove_tuple(
 
     EtsMultimapEntry **to_remove = malloc(sizeof(EtsMultimapEntry *) * capacity);
     if (IS_NULL_PTR(to_remove)) {
-        return EtsMultimapAllocationError;
+        return Popcorn2EtsAllocationError;
     }
 
     for (EtsMultimapEntry *iter = node->entries; iter != NULL; iter = iter->next) {
@@ -291,7 +291,7 @@ EtsMultimapStatus ets_multimap_remove_tuple(
 
         if (UNLIKELY(result == TermCompareMemoryAllocFail)) {
             free(to_remove);
-            return EtsMultimapAllocationError;
+            return Popcorn2EtsAllocationError;
         }
 
         if (result == TermEquals) {
@@ -300,7 +300,7 @@ EtsMultimapStatus ets_multimap_remove_tuple(
                 EtsMultimapEntry **new_to_remove = realloc(to_remove, sizeof(EtsMultimapEntry *) * capacity);
                 if (IS_NULL_PTR(new_to_remove)) {
                     free(to_remove);
-                    return EtsMultimapAllocationError;
+                    return Popcorn2EtsAllocationError;
                 }
                 to_remove = new_to_remove;
             }
@@ -345,10 +345,10 @@ EtsMultimapStatus ets_multimap_remove_tuple(
 
     free(to_remove);
 
-    return EtsMultimapOk;
+    return Popcorn2EtsOk;
 }
 
-static EtsMultimapStatus node_find(
+static Popcorn2EtsStatus node_find(
     EtsMultimap *multimap,
     term key,
     EtsMultimapNode **out_node,
@@ -362,25 +362,25 @@ static EtsMultimapStatus node_find(
     EtsMultimapNode *node = multimap->buckets[idx];
 
     if (node == NULL) {
-        return EtsMultimapOk;
+        return Popcorn2EtsOk;
     }
 
     while (node) {
         TermCompareResult result = term_compare(key, node_key(multimap, node), TermCompareExact, global);
 
         if (UNLIKELY(result == TermCompareMemoryAllocFail)) {
-            return EtsMultimapAllocationError;
+            return Popcorn2EtsAllocationError;
         }
 
         if (result == TermEquals) {
             *out_node = node;
-            return EtsMultimapOk;
+            return Popcorn2EtsOk;
         }
 
         node = node->next;
     }
 
-    return EtsMultimapOk;
+    return Popcorn2EtsOk;
 }
 
 static void insert_revert(
@@ -442,7 +442,7 @@ static void multimap_to_single(EtsMultimap *multimap, GlobalContext *global)
     }
 }
 
-static EtsMultimapStatus tuple_exists(
+static Popcorn2EtsStatus tuple_exists(
     EtsMultimapNode *node,
     term tuple,
     bool *exists,
@@ -452,17 +452,17 @@ static EtsMultimapStatus tuple_exists(
         TermCompareResult result = term_compare(tuple, iter->tuple, TermCompareExact, global);
 
         if (UNLIKELY(result == TermCompareMemoryAllocFail)) {
-            return EtsMultimapAllocationError;
+            return Popcorn2EtsAllocationError;
         }
 
         if (result == TermEquals) {
             *exists = true;
-            return EtsMultimapOk;
+            return Popcorn2EtsOk;
         }
     }
 
     *exists = false;
-    return EtsMultimapOk;
+    return Popcorn2EtsOk;
 }
 
 static term node_key(EtsMultimap *multimap, EtsMultimapNode *node)

--- a/src/libAtomVM/popcorn/popcorn_ets_multimap.h
+++ b/src/libAtomVM/popcorn/popcorn_ets_multimap.h
@@ -37,15 +37,6 @@ typedef enum EtsMultimapType
     EtsMultimapTypeList // Allow duplicate values per key
 } EtsMultimapType;
 
-typedef enum EtsMultimapStatus
-{
-    EtsMultimapOk,
-    EtsMultimapKeyExists,
-    EtsMultimapTupleNotExists,
-    EtsMultimapBadTuple,
-    EtsMultimapAllocationError
-} EtsMultimapStatus;
-
 typedef struct EtsMultimap
 {
     EtsMultimapType type;
@@ -91,7 +82,7 @@ void ets_multimap_delete(EtsMultimap *multimap, GlobalContext *global);
  * @param[out] tuples the found tuples (or NULL to only get the count)
  * @param[out] count the number of found tuples; must not be NULL
  * @param global the global context
- * @return EtsMultimapOk on success, otherwise an error status
+ * @return EtsOk on success, otherwise an error status
  *
  * @note Terms returned by this function come from the ETS heap and should be copied
  *       to the process heap if needed.
@@ -100,7 +91,7 @@ void ets_multimap_delete(EtsMultimap *multimap, GlobalContext *global);
  * @warning The caller is responsible for freeing the memory pointed to by `tuples`
  *          using `free()`. When count is zero, memory is not allocated and `tuples` is set to NULL.
  */
-EtsMultimapStatus ets_multimap_lookup(
+Popcorn2EtsStatus ets_multimap_lookup(
     EtsMultimap *multimap,
     term key,
     term **tuples,
@@ -113,11 +104,11 @@ EtsMultimapStatus ets_multimap_lookup(
  * @param multimap the multimap
  * @param tuples the tuples to insert
  * @param count the number of tuples to insert
- * @return EtsMultimapOk on success, otherwise an error status
+ * @return EtsOk on success, otherwise an error status
  *
  * @note Terms passed to this function will be copied to the ETS heap.
  */
-EtsMultimapStatus ets_multimap_insert(
+Popcorn2EtsStatus ets_multimap_insert(
     EtsMultimap *multimap,
     term *tuples,
     size_t count,
@@ -129,9 +120,9 @@ EtsMultimapStatus ets_multimap_insert(
  * @param multimap the multimap
  * @param key the key to lookup
  * @param global the global context
- * @return EtsMultimapOk on success, otherwise an error status
+ * @return EtsOk on success, otherwise an error status
  */
-EtsMultimapStatus ets_multimap_remove(
+Popcorn2EtsStatus ets_multimap_remove(
     EtsMultimap *multimap,
     term key,
     GlobalContext *global);
@@ -142,9 +133,9 @@ EtsMultimapStatus ets_multimap_remove(
  * @param multimap the multimap
  * @param tuple the tuple to remove
  * @param global the global context
- * @return EtsMultimapOk on success, otherwise an error status
+ * @return EtsOk on success, otherwise an error status
  */
-EtsMultimapStatus ets_multimap_remove_tuple(
+Popcorn2EtsStatus ets_multimap_remove_tuple(
     EtsMultimap *multimap,
     term tuple,
     GlobalContext *global);

--- a/src/libAtomVM/popcorn/popcorn_ets_multimap_hash.h
+++ b/src/libAtomVM/popcorn/popcorn_ets_multimap_hash.h
@@ -196,7 +196,7 @@ static uint32_t hash_term_incr(term t, int32_t h, GlobalContext *global)
         }
         return h * LARGE_PRIME_TUPLE;
     } else if (term_is_list(t)) {
-        while (!term_is_nonempty_list(t)) {
+        while (term_is_nonempty_list(t)) {
             term elt = term_get_list_head(t);
             h = h * LARGE_PRIME_LIST + hash_term_incr(elt, h, global);
             t = term_get_list_tail(t);

--- a/src/libAtomVM/popcorn/popcorn_nifs.c
+++ b/src/libAtomVM/popcorn/popcorn_nifs.c
@@ -595,7 +595,7 @@ static term nif_ets_new(Context *ctx, int argc, term argv[])
         case Popcorn2EtsTableNameExists:
             RAISE_ERROR(BADARG_ATOM);
         case Popcorn2EtsAllocationError:
-            RAISE_ERROR(MEMORY_ATOM);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             // unreachable
             AVM_ABORT();
@@ -704,7 +704,7 @@ static term nif_ets_member(Context *ctx, int argc, term argv[])
         case PopcornEtsBadAccess:
             RAISE_ERROR(BADARG_ATOM);
         case PopcornEtsAllocationFailure:
-            RAISE_ERROR(MEMORY_ATOM);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             AVM_ABORT();
     }
@@ -731,7 +731,7 @@ static term nif_ets_take(Context *ctx, int argc, term argv[])
         case Popcorn2EtsBadAccess:
             RAISE_ERROR(BADARG_ATOM);
         case Popcorn2EtsAllocationError:
-            RAISE_ERROR(MEMORY_ATOM);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             // unreachable
             AVM_ABORT();
@@ -760,7 +760,7 @@ static term nif_ets_update_counter(Context *ctx, int argc, term argv[])
         case PopcornEtsBadEntry:
             RAISE_ERROR(BADARG_ATOM);
         case PopcornEtsAllocationFailure:
-            RAISE_ERROR(MEMORY_ATOM);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             AVM_ABORT();
     }
@@ -791,7 +791,7 @@ static term nif_ets_update_element(Context *ctx, int argc, term argv[])
         case Popcorn2EtsBadEntry:
             RAISE_ERROR(BADARG_ATOM);
         case Popcorn2EtsAllocationError:
-            RAISE_ERROR(MEMORY_ATOM);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             AVM_ABORT();
     }
@@ -834,7 +834,7 @@ static term nif_ets_lookup_element(Context *ctx, int argc, term argv[])
         case Popcorn2EtsBadIndex:
             RAISE_ERROR(BADARG_ATOM);
         case Popcorn2EtsAllocationError:
-            RAISE_ERROR(MEMORY_ATOM);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             AVM_ABORT();
     }
@@ -886,7 +886,7 @@ static term nif_ets_delete_object(Context *ctx, int argc, term argv[])
         case Popcorn2EtsBadEntry:
             RAISE_ERROR(BADARG_ATOM);
         case Popcorn2EtsAllocationError:
-            RAISE_ERROR(MEMORY_ATOM);
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             // unreachable
             AVM_ABORT();

--- a/src/libAtomVM/popcorn/popcorn_nifs.c
+++ b/src/libAtomVM/popcorn/popcorn_nifs.c
@@ -712,23 +712,28 @@ static term nif_ets_member(Context *ctx, int argc, term argv[])
 
 static term nif_ets_take(Context *ctx, int argc, term argv[])
 {
-    UNUSED(argc);
+    assert(argc == 2);
 
-    term ref = argv[0];
-    VALIDATE_VALUE(ref, is_ets_table_id);
-
+    term name_or_ref = argv[0];
     term key = argv[1];
 
+    VALIDATE_VALUE(name_or_ref, is_ets_table_id);
+
     term ret = term_invalid_term();
-    PopcornEtsErrorCode result = popcorn_ets_take(ref, key, &ret, ctx);
+
+    Popcorn2EtsStatus result = popcorn2_ets_take(name_or_ref, key, &ret, ctx);
+
     switch (result) {
-        case PopcornEtsOk:
+        case Popcorn2EtsOk:
             return ret;
-        case PopcornEtsBadAccess:
+        case Popcorn2EtsTupleNotExists:
+            return term_nil();
+        case Popcorn2EtsBadAccess:
             RAISE_ERROR(BADARG_ATOM);
-        case PopcornEtsAllocationFailure:
+        case Popcorn2EtsAllocationError:
             RAISE_ERROR(MEMORY_ATOM);
         default:
+            // unreachable
             AVM_ABORT();
     }
 }

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -37,6 +37,7 @@ start() ->
     ok = isolated(fun test_delete_object/0),
     ok = isolated(fun test_lookup_element/0),
     ok = isolated(fun test_update_element/0),
+    ok = isolated(fun test_take/0),
     % ok = isolated(fun test_update_counter/0),
     0.
 
@@ -131,6 +132,7 @@ test_keys() ->
     ok = assert_stored_key(T, <<"bin">>),
     ok = assert_stored_key(T, <<"">>),
     ok = assert_stored_key(T, {ok, 1}),
+    ok = assert_stored_key(T, []),
     ok = assert_stored_key(T, [x, self(), 1.0]),
     ok = assert_stored_key(T, [improper | list]),
     ok = assert_stored_key(T, #{
@@ -570,6 +572,36 @@ test_update_element() ->
 
     [{value1, value2, key}] = ets:lookup(TErr, key),
     [] = ets:lookup(TErr, key_not_exist),
+
+    ok.
+
+test_take() ->
+    % set
+    S = ets:new(test, [set]),
+    [] = ets:take(S, key_not_exist),
+    true = ets:insert(S, [{key, value}, {key2, value2}]),
+    [{key, value}] = ets:take(S, key),
+    [] = ets:lookup(S, key),
+    [{key2, value2}] = ets:take(S, key2),
+    [] = ets:lookup(S, key2),
+
+    % bag
+    B = ets:new(test, [bag]),
+    [] = ets:take(B, key_not_exist),
+    true = ets:insert(B, [{key, value}, {key, value2}, {key2, value3}]),
+    [{key, value}, {key, value2}] = ets:take(B, key),
+    [] = ets:lookup(B, key),
+    [{key2, value3}] = ets:take(B, key2),
+    [] = ets:lookup(B, key2), 
+
+    % duplicate_bag
+    DB = ets:new(test, [duplicate_bag]),
+    [] = ets:take(DB, key_not_exist),
+    true = ets:insert(DB, [{key, value}, {key, value}, {key2, value2}]),
+    [{key, value}, {key, value}] = ets:take(DB, key),
+    [] = ets:lookup(DB, key),
+    [{key2, value2}] = ets:take(DB, key2),
+    [] = ets:lookup(DB, key2), 
 
     ok.
 

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -576,32 +576,39 @@ test_update_element() ->
     ok.
 
 test_take() ->
+    TableWithTuples =
+        fun (Type, Tuples) ->
+            T = ets:new(test, [Type]),
+            true = ets:insert(T, Tuples),
+            T
+        end,
+
     % set
-    S = ets:new(test, [set]),
-    [] = ets:take(S, key_not_exist),
-    true = ets:insert(S, [{key, value}, {key2, value2}]),
-    [{key, value}] = ets:take(S, key),
-    [] = ets:lookup(S, key),
-    [{key2, value2}] = ets:take(S, key2),
-    [] = ets:lookup(S, key2),
+    S1 = TableWithTuples(set, []),
+    [] = ets:take(S1, key_not_exist),
+
+    S2 = TableWithTuples(set, [{key, value}, {key2, value2}]),
+    [{key, value}] = ets:take(S2, key),
+    [] = ets:lookup(S2, key),
+    [{key2, value2}] = ets:lookup(S2, key2),
 
     % bag
-    B = ets:new(test, [bag]),
-    [] = ets:take(B, key_not_exist),
-    true = ets:insert(B, [{key, value}, {key, value2}, {key2, value3}]),
-    [{key, value}, {key, value2}] = ets:take(B, key),
-    [] = ets:lookup(B, key),
-    [{key2, value3}] = ets:take(B, key2),
-    [] = ets:lookup(B, key2), 
+    B1 = TableWithTuples(bag, []),
+    [] = ets:take(B1, key_not_exist),
+
+    B2 = TableWithTuples(bag, [{key, value}, {key, value2}, {key2, value3}]),
+    [{key, value}, {key, value2}] = ets:take(B2, key),
+    [] = ets:lookup(B2, key),
+    [{key2, value3}] = ets:lookup(B2, key2),
 
     % duplicate_bag
-    DB = ets:new(test, [duplicate_bag]),
-    [] = ets:take(DB, key_not_exist),
-    true = ets:insert(DB, [{key, value}, {key, value}, {key2, value2}]),
-    [{key, value}, {key, value}] = ets:take(DB, key),
-    [] = ets:lookup(DB, key),
-    [{key2, value2}] = ets:take(DB, key2),
-    [] = ets:lookup(DB, key2), 
+    DB1 = TableWithTuples(duplicate_bag, []),
+    [] = ets:take(DB1, key_not_exist),
+
+    DB2 = TableWithTuples(duplicate_bag, [{key, value}, {key, value}, {key2, value2}]),
+    [{key, value}, {key, value}] = ets:take(DB2, key),
+    [] = ets:lookup(DB2, key),
+    [{key2, value2}] = ets:lookup(DB2, key2),
 
     ok.
 


### PR DESCRIPTION
This PR implements the `take/2` function and adds some minor changes.

Minor changes:
- Replace `EtsMultimapStatus` with `Popcorn2EtsStatus`
- Fix list iteration condition in `hash_term`
- Raise `OUT_OF_MEMORY_ATOM` instead of `MEMORY_ATOM`