### PR TITLE
Implement ETS `update_counter/4`

### DIFF
--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -784,6 +784,9 @@ static Popcorn2EtsStatus lookup_or_default(
     term *tuple = NULL;
     size_t count;
     Popcorn2EtsStatus result = ets_multimap_lookup(table->multimap, key, &tuple, &count, ctx->global);
+    if (result != Popcorn2EtsOk) {
+        return result;
+    }
 
     bool insert_default = (count == 0);
 
@@ -792,7 +795,7 @@ static Popcorn2EtsStatus lookup_or_default(
     }
 
     if (insert_default) {
-        if (term_get_tuple_arity(default_tuple) <= table->key_index) {
+        if ((size_t) term_get_tuple_arity(default_tuple) <= table->key_index) {
             return Popcorn2EtsBadEntry;
         }
         tuple = &default_tuple;
@@ -828,7 +831,7 @@ static bool apply_spec(term tuple, term spec, size_t key_index)
 
     avm_int_t index = term_to_int(pos) - 1;
 
-    if (index < 0 || (size_t) index >= term_get_tuple_arity(tuple)) {
+    if (index < 0 || index >= term_get_tuple_arity(tuple)) {
         return false;
     }
 
@@ -858,7 +861,11 @@ static bool apply_op(term tuple, term op, avm_int_t *ret, size_t key_index)
     }
 
     avm_int_t index = term_to_int(pos) - 1;
-    if (index < 0 || (size_t) index >= term_get_tuple_arity(tuple) || (size_t) index == key_index) {
+    if (index < 0 || index >= term_get_tuple_arity(tuple)) {
+        return false;
+    }
+
+    if ((size_t) index == key_index) {
         return false;
     }
 

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -25,6 +25,7 @@
 #include "../defaultatoms.h"
 #include "../list.h"
 #include "../memory.h"
+#include "../overflow_helpers.h"
 #include "../term.h"
 #include "../utils.h"
 
@@ -100,10 +101,11 @@ static Popcorn2EtsStatus lookup_or_default(
     struct Popcorn2EtsTable *table,
     term key,
     term default_tuple,
-    term *to_insert,
+    Heap *ret_heap,
+    term *ret,
     Context *ctx);
-static bool apply_spec(term tuple, term spec, size_t key_index);
-static bool apply_op(term tuple, term opt, avm_int_t *ret, size_t key_index);
+static Popcorn2EtsStatus apply_spec(term tuple, term spec, size_t key_index);
+static Popcorn2EtsStatus apply_op(term tuple, term opt, avm_int_t *ret, size_t key_index);
 
 void popcorn2_ets_init(Popcorn2Ets *ets)
 {
@@ -276,38 +278,40 @@ Popcorn2EtsStatus popcorn2_ets_update_element(
         return Popcorn2EtsBadAccess;
     }
 
-    term to_insert;
-    Popcorn2EtsStatus result = lookup_or_default(table, key, default_tuple, &to_insert, ctx);
+    Heap insert_heap;
+    term insert_tuple;
+    Popcorn2EtsStatus result = lookup_or_default(table, key, default_tuple, &insert_heap, &insert_tuple, ctx);
     if (result != Popcorn2EtsOk) {
         SMP_UNLOCK(table);
         return result;
     }
 
     if (term_is_tuple(element_spec)) {
-        if (!apply_spec(to_insert, element_spec, table->key_index)) {
-            SMP_UNLOCK(table);
-            return Popcorn2EtsBadEntry;
+        result = apply_spec(insert_tuple, element_spec, table->key_index);
+        if (result != Popcorn2EtsOk) {
+            goto cleanup;
         }
     } else if (term_is_list(element_spec)) {
         for (term iter = element_spec; !term_is_nil(iter); iter = term_get_list_tail(iter)) {
             if (!term_is_list(iter)) {
-                SMP_UNLOCK(table);
-                return Popcorn2EtsBadEntry;
+                result = Popcorn2EtsBadEntry;
+                goto cleanup;
             }
 
             term spec = term_get_list_head(iter);
 
-            if (!apply_spec(to_insert, spec, table->key_index)) {
-                SMP_UNLOCK(table);
-                return Popcorn2EtsBadEntry;
+            result = apply_spec(insert_tuple, spec, table->key_index);
+            if (result != Popcorn2EtsOk) {
+                goto cleanup;
             }
         }
     }
 
-    result = ets_multimap_insert(table->multimap, &to_insert, 1, ctx->global);
+    result = ets_multimap_insert(table->multimap, &insert_tuple, 1, ctx->global);
 
+cleanup:
+    memory_destroy_heap(&insert_heap, ctx->global);
     SMP_UNLOCK(table);
-
     return result;
 }
 
@@ -352,8 +356,9 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
         return Popcorn2EtsBadAccess;
     }
 
-    term to_insert;
-    Popcorn2EtsStatus result = lookup_or_default(table, key, default_tuple, &to_insert, ctx);
+    Heap insert_heap;
+    term insert_tuple;
+    Popcorn2EtsStatus result = lookup_or_default(table, key, default_tuple, &insert_heap, &insert_tuple, ctx);
     if (result != Popcorn2EtsOk) {
         SMP_UNLOCK(table);
         return result;
@@ -362,66 +367,68 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
     if (term_is_integer(op)) {
         avm_int_t index = (avm_int_t) table->key_index + 1;
 
-        if (term_get_tuple_arity(to_insert) <= index) {
-            SMP_UNLOCK(table);
-            return Popcorn2EtsBadEntry;
+        if (index >= term_get_tuple_arity(insert_tuple)) {
+            result = Popcorn2EtsBadEntry;
+            goto cleanup;
         }
 
-        term value = term_get_tuple_element(to_insert, (uint32_t) index);
-
+        term value = term_get_tuple_element(insert_tuple, (uint32_t) index);
         if (!term_is_integer(value)) {
-            SMP_UNLOCK(table);
-            return Popcorn2EtsBadEntry;
+            result = Popcorn2EtsBadEntry;
+            goto cleanup;
         }
 
-        avm_int_t current = term_to_int(value);
-        avm_int_t delta = term_to_int(op);
-        term new_value = term_from_int(current + delta);
+        avm_int_t new_value;
+        if (BUILTIN_ADD_OVERFLOW_INT(term_to_int(value), term_to_int(op), &new_value)) {
+            result = Popcorn2EtsOverflow;
+            goto cleanup;
+        }
 
-        term_put_tuple_element(to_insert, (uint32_t) index, new_value);
+        term_put_tuple_element(insert_tuple, (uint32_t) index, term_from_int(new_value));
 
-        *ret = new_value;
+        *ret = term_from_int(new_value);
     } else if (term_is_tuple(op)) {
         avm_int_t value;
-        if (!apply_op(to_insert, op, &value, table->key_index)) {
-            SMP_UNLOCK(table);
-            return Popcorn2EtsBadEntry;
+
+        result = apply_op(insert_tuple, op, &value, table->key_index);
+        if (result != Popcorn2EtsOk) {
+            goto cleanup;
         }
+
         *ret = term_from_int(value);
     } else if (term_is_list(op)) {
         size_t num_ops = 0;
         for (term iter = op; !term_is_nil(iter); iter = term_get_list_tail(iter)) {
             if (!term_is_list(iter)) {
-                SMP_UNLOCK(table);
-                return Popcorn2EtsBadEntry;
+                result = Popcorn2EtsBadEntry;
+                goto cleanup;
             }
             num_ops++;
         }
 
         if (num_ops == 0) {
             *ret = term_nil();
-            SMP_UNLOCK(table);
-            return Popcorn2EtsOk;
+            goto cleanup;
         }
 
         if (UNLIKELY(memory_ensure_free_opt(ctx, num_ops * CONS_SIZE, MEMORY_NO_GC) != MEMORY_GC_OK)) {
-            SMP_UNLOCK(table);
-            return Popcorn2EtsAllocationError;
+            result = Popcorn2EtsAllocationError;
+            goto cleanup;
         }
 
         avm_int_t *values = malloc(sizeof(avm_int_t) * num_ops);
         if (IS_NULL_PTR(values)) {
-            SMP_UNLOCK(table);
-            return Popcorn2EtsAllocationError;
+            result = Popcorn2EtsAllocationError;
+            goto cleanup;
         }
 
         size_t i = 0;
         for (term iter = op; !term_is_nil(iter); iter = term_get_list_tail(iter), i++) {
-            term spec = term_get_list_head(iter);
-            if (!apply_op(to_insert, spec, &values[i], table->key_index)) {
+            term entry = term_get_list_head(iter);
+            result = apply_op(insert_tuple, entry, &values[i], table->key_index);
+            if (result != Popcorn2EtsOk) {
                 free(values);
-                SMP_UNLOCK(table);
-                return Popcorn2EtsBadEntry;
+                goto cleanup;
             }
         }
 
@@ -435,14 +442,15 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
 
         *ret = list;
     } else {
-        SMP_UNLOCK(table);
-        return Popcorn2EtsBadEntry;
+        result = Popcorn2EtsBadEntry;
+        goto cleanup;
     }
 
-    result = ets_multimap_insert(table->multimap, &to_insert, 1, ctx->global);
+    result = ets_multimap_insert(table->multimap, &insert_tuple, 1, ctx->global);
 
+cleanup:
+    memory_destroy_heap(&insert_heap, ctx->global);
     SMP_UNLOCK(table);
-
     return result;
 }
 
@@ -776,7 +784,8 @@ static Popcorn2EtsStatus lookup_or_default(
     struct Popcorn2EtsTable *table,
     term key,
     term default_tuple,
-    term *to_insert,
+    Heap *ret_heap,
+    term *ret,
     Context *ctx)
 {
     if (table->type != Popcorn2EtsTableSet) {
@@ -805,88 +814,91 @@ static Popcorn2EtsStatus lookup_or_default(
 
     size_t tuple_size = memory_estimate_usage(*tuple);
 
-    if (UNLIKELY(memory_ensure_free_opt(ctx, tuple_size, MEMORY_NO_GC) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_init_heap(ret_heap, tuple_size) != MEMORY_GC_OK)) {
         return Popcorn2EtsAllocationError;
     }
 
-    *to_insert = memory_copy_term_tree(&ctx->heap, *tuple);
+    *ret = memory_copy_term_tree(ret_heap, *tuple);
 
     if (insert_default) {
-        term_put_tuple_element(*to_insert, (uint32_t) table->key_index, key);
+        term_put_tuple_element(*ret, (uint32_t) table->key_index, key);
     }
 
     return Popcorn2EtsOk;
 }
 
-static bool apply_spec(term tuple, term spec, size_t key_index)
+static Popcorn2EtsStatus apply_spec(term tuple, term spec, size_t key_index)
 {
     if (!term_is_tuple(spec) || term_get_tuple_arity(spec) != 2) {
-        return false;
+        return Popcorn2EtsBadEntry;
     }
 
     term pos = term_get_tuple_element(spec, 0);
     term value = term_get_tuple_element(spec, 1);
 
     if (!term_is_integer(pos)) {
-        return false;
+        return Popcorn2EtsBadEntry;
     }
 
     avm_int_t index = term_to_int(pos) - 1;
 
     if (index < 0 || index >= term_get_tuple_arity(tuple)) {
-        return false;
+        return Popcorn2EtsBadEntry;
     }
 
     if ((size_t) index == key_index) {
-        return false;
+        return Popcorn2EtsBadEntry;
     }
 
     term_put_tuple_element(tuple, (uint32_t) index, value);
-    return true;
+    return Popcorn2EtsOk;
 }
 
-static bool apply_op(term tuple, term op, avm_int_t *ret, size_t key_index)
+static Popcorn2EtsStatus apply_op(term tuple, term op, avm_int_t *ret, size_t key_index)
 {
     assert(term_is_tuple(op));
 
     int arity = term_get_tuple_arity(op);
 
     if (arity != 2 && arity != 4) {
-        return false;
+        return Popcorn2EtsBadEntry;
     }
 
     term pos = term_get_tuple_element(op, 0);
     term incr = term_get_tuple_element(op, 1);
 
     if (!term_is_integer(pos) || !term_is_integer(incr)) {
-        return false;
+        return Popcorn2EtsBadEntry;
     }
 
     avm_int_t index = term_to_int(pos) - 1;
     if (index < 0 || index >= term_get_tuple_arity(tuple)) {
-        return false;
+        return Popcorn2EtsBadEntry;
     }
 
     if ((size_t) index == key_index) {
-        return false;
+        return Popcorn2EtsBadEntry;
     }
 
     term value = term_get_tuple_element(tuple, (uint32_t) index);
 
     if (!term_is_integer(value)) {
-        return false;
+        return Popcorn2EtsBadEntry;
     }
 
     avm_int_t current = term_to_int(value);
     avm_int_t delta = term_to_int(incr);
-    avm_int_t new_value = current + delta;
+    avm_int_t new_value;
+    if (BUILTIN_ADD_OVERFLOW_INT(current, delta, &new_value)) {
+        return Popcorn2EtsOverflow;
+    }
 
     if (arity == 4) {
         term threshold = term_get_tuple_element(op, 2);
         term setvalue = term_get_tuple_element(op, 3);
 
         if (!term_is_integer(threshold) || !term_is_integer(setvalue)) {
-            return false;
+            return Popcorn2EtsBadEntry;
         }
 
         avm_int_t thresh = term_to_int(threshold);
@@ -900,5 +912,5 @@ static bool apply_op(term tuple, term op, avm_int_t *ret, size_t key_index)
     term_put_tuple_element(tuple, index, term_from_int(new_value));
     *ret = new_value;
 
-    return true;
+    return Popcorn2EtsOk;
 }

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -411,7 +411,7 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
             goto cleanup;
         }
 
-        if (UNLIKELY(memory_ensure_free_opt(ctx, num_ops * CONS_SIZE, MEMORY_NO_GC) != MEMORY_GC_OK)) {
+        if (UNLIKELY(memory_ensure_free_with_roots(ctx, num_ops * CONS_SIZE, 1, &op, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
             result = Popcorn2EtsAllocationError;
             goto cleanup;
         }

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -360,7 +360,14 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
     }
 
     if (term_is_integer(op)) {
-        term value = term_get_tuple_element(to_insert, (uint32_t) table->key_index + 1);
+        avm_int_t index = (avm_int_t) table->key_index + 1;
+
+        if (term_get_tuple_arity(to_insert) <= index) {
+            SMP_UNLOCK(table);
+            return Popcorn2EtsBadEntry;
+        }
+
+        term value = term_get_tuple_element(to_insert, (uint32_t) index);
 
         if (!term_is_integer(value)) {
             SMP_UNLOCK(table);
@@ -371,7 +378,7 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
         avm_int_t delta = term_to_int(op);
         term new_value = term_from_int(current + delta);
 
-        term_put_tuple_element(to_insert, (uint32_t) table->key_index + 1, new_value);
+        term_put_tuple_element(to_insert, (uint32_t) index, new_value);
 
         *ret = new_value;
     } else if (term_is_tuple(op)) {

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -355,15 +355,16 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
     term to_insert;
     Popcorn2EtsStatus result = lookup_or_default(table, key, default_tuple, &to_insert, ctx);
     if (result != Popcorn2EtsOk) {
-        goto cleanup;
+        SMP_UNLOCK(table);
+        return result;
     }
 
     if (term_is_integer(operation)) {
         term value = term_get_tuple_element(to_insert, (uint32_t) table->key_index + 1);
 
         if (!term_is_integer(value)) {
-            result = Popcorn2EtsBadEntry;
-            goto cleanup;
+            SMP_UNLOCK(table);
+            return Popcorn2EtsBadEntry;
         }
 
         avm_int_t current = term_to_int(value);
@@ -376,35 +377,35 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
     } else if (term_is_tuple(operation)) {
         avm_int_t value;
         if (!apply_opt(to_insert, operation, &value, table->key_index)) {
-            result = Popcorn2EtsBadEntry;
-            goto cleanup;
+            SMP_UNLOCK(table);
+            return Popcorn2EtsBadEntry;
         }
         *ret = term_from_int(value);
     } else if (term_is_list(operation)) {
         size_t num_ops = 0;
         for (term iter = operation; !term_is_nil(iter); iter = term_get_list_tail(iter)) {
             if (!term_is_list(iter)) {
-                result = Popcorn2EtsBadEntry;
-                goto cleanup;
+                SMP_UNLOCK(table);
+                return Popcorn2EtsBadEntry;
             }
             num_ops++;
         }
 
         if (num_ops == 0) {
             *ret = term_nil();
-            result = Popcorn2EtsOk;
-            goto cleanup;
+            SMP_UNLOCK(table);
+            return Popcorn2EtsOk;
         }
 
         if (UNLIKELY(memory_ensure_free_opt(ctx, num_ops * CONS_SIZE, MEMORY_NO_GC) != MEMORY_GC_OK)) {
-            result = Popcorn2EtsAllocationError;
-            goto cleanup;
+            SMP_UNLOCK(table);
+            return Popcorn2EtsAllocationError;
         }
 
         avm_int_t *values = malloc(sizeof(avm_int_t) * num_ops);
         if (IS_NULL_PTR(values)) {
-            result = Popcorn2EtsAllocationError;
-            goto cleanup;
+            SMP_UNLOCK(table);
+            return Popcorn2EtsAllocationError;
         }
 
         size_t i = 0;
@@ -412,8 +413,8 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
             term spec = term_get_list_head(iter);
             if (!apply_opt(to_insert, spec, &values[i], table->key_index)) {
                 free(values);
-                result = Popcorn2EtsBadEntry;
-                goto cleanup;
+                SMP_UNLOCK(table);
+                return Popcorn2EtsBadEntry;
             }
         }
 
@@ -425,14 +426,14 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
 
         *ret = list;
     } else {
-        result = Popcorn2EtsBadEntry;
-        goto cleanup;
+        SMP_UNLOCK(table);
+        return Popcorn2EtsBadEntry;
     }
 
     result = ets_multimap_insert(table->multimap, &to_insert, 1, ctx->global);
 
-cleanup:
     SMP_UNLOCK(table);
+
     return result;
 }
 

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -103,7 +103,7 @@ static Popcorn2EtsStatus lookup_or_default(
     term *to_insert,
     Context *ctx);
 static bool apply_spec(term tuple, term spec, size_t key_index);
-static bool apply_opt(term tuple, term opt, avm_int_t *ret, size_t key_index);
+static bool apply_op(term tuple, term opt, avm_int_t *ret, size_t key_index);
 
 void popcorn2_ets_init(Popcorn2Ets *ets)
 {
@@ -337,7 +337,7 @@ Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Conte
 Popcorn2EtsStatus popcorn2_ets_update_counter(
     term name_or_ref,
     term key,
-    term operation,
+    term op,
     term default_tuple,
     term *ret,
     Context *ctx)
@@ -359,7 +359,7 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
         return result;
     }
 
-    if (term_is_integer(operation)) {
+    if (term_is_integer(op)) {
         term value = term_get_tuple_element(to_insert, (uint32_t) table->key_index + 1);
 
         if (!term_is_integer(value)) {
@@ -368,22 +368,22 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
         }
 
         avm_int_t current = term_to_int(value);
-        avm_int_t delta = term_to_int(operation);
+        avm_int_t delta = term_to_int(op);
         term new_value = term_from_int(current + delta);
 
         term_put_tuple_element(to_insert, (uint32_t) table->key_index + 1, new_value);
 
         *ret = new_value;
-    } else if (term_is_tuple(operation)) {
+    } else if (term_is_tuple(op)) {
         avm_int_t value;
-        if (!apply_opt(to_insert, operation, &value, table->key_index)) {
+        if (!apply_op(to_insert, op, &value, table->key_index)) {
             SMP_UNLOCK(table);
             return Popcorn2EtsBadEntry;
         }
         *ret = term_from_int(value);
-    } else if (term_is_list(operation)) {
+    } else if (term_is_list(op)) {
         size_t num_ops = 0;
-        for (term iter = operation; !term_is_nil(iter); iter = term_get_list_tail(iter)) {
+        for (term iter = op; !term_is_nil(iter); iter = term_get_list_tail(iter)) {
             if (!term_is_list(iter)) {
                 SMP_UNLOCK(table);
                 return Popcorn2EtsBadEntry;
@@ -409,9 +409,9 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
         }
 
         size_t i = 0;
-        for (term iter = operation; !term_is_nil(iter); iter = term_get_list_tail(iter), i++) {
+        for (term iter = op; !term_is_nil(iter); iter = term_get_list_tail(iter), i++) {
             term spec = term_get_list_head(iter);
-            if (!apply_opt(to_insert, spec, &values[i], table->key_index)) {
+            if (!apply_op(to_insert, spec, &values[i], table->key_index)) {
                 free(values);
                 SMP_UNLOCK(table);
                 return Popcorn2EtsBadEntry;
@@ -833,20 +833,18 @@ static bool apply_spec(term tuple, term spec, size_t key_index)
     return true;
 }
 
-static bool apply_opt(term tuple, term opt, avm_int_t *ret, size_t key_index)
+static bool apply_op(term tuple, term op, avm_int_t *ret, size_t key_index)
 {
-    if (!term_is_tuple(opt)) {
-        return false;
-    }
+    assert(term_is_tuple(op));
 
-    int arity = term_get_tuple_arity(opt);
+    int arity = term_get_tuple_arity(op);
 
     if (arity != 2 && arity != 4) {
         return false;
     }
 
-    term pos = term_get_tuple_element(opt, 0);
-    term incr = term_get_tuple_element(opt, 1);
+    term pos = term_get_tuple_element(op, 0);
+    term incr = term_get_tuple_element(op, 1);
 
     if (!term_is_integer(pos) || !term_is_integer(incr)) {
         return false;
@@ -868,8 +866,8 @@ static bool apply_opt(term tuple, term opt, avm_int_t *ret, size_t key_index)
     avm_int_t new_value = current + delta;
 
     if (arity == 4) {
-        term threshold = term_get_tuple_element(opt, 2);
-        term setvalue = term_get_tuple_element(opt, 3);
+        term threshold = term_get_tuple_element(op, 2);
+        term setvalue = term_get_tuple_element(op, 3);
 
         if (!term_is_integer(threshold) || !term_is_integer(setvalue)) {
             return false;

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -96,7 +96,7 @@ static Popcorn2EtsStatus lookup_select(
     size_t index,
     term *ret,
     Context *ctx);
-static Popcorn2EtsStatus prepare_update(
+static Popcorn2EtsStatus lookup_or_default(
     struct Popcorn2EtsTable *table,
     term key,
     term default_tuple,
@@ -383,7 +383,7 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
     }
 
     term to_insert;
-    Popcorn2EtsStatus result = prepare_update(table, key, default_tuple, &to_insert, ctx);
+    Popcorn2EtsStatus result = lookup_or_default(table, key, default_tuple, &to_insert, ctx);
     if (result != Popcorn2EtsOk) {
         goto cleanup;
     }
@@ -792,7 +792,7 @@ static Popcorn2EtsStatus lookup_select(
     return Popcorn2EtsOk;
 }
 
-static Popcorn2EtsStatus prepare_update(
+static Popcorn2EtsStatus lookup_or_default(
     struct Popcorn2EtsTable *table,
     term key,
     term default_tuple,

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -276,41 +276,11 @@ Popcorn2EtsStatus popcorn2_ets_update_element(
         return Popcorn2EtsBadAccess;
     }
 
-    if (table->type != Popcorn2EtsTableSet) {
+    term to_insert;
+    Popcorn2EtsStatus result = lookup_or_default(table, key, default_tuple, &to_insert, ctx);
+    if (result != Popcorn2EtsOk) {
         SMP_UNLOCK(table);
-        return Popcorn2EtsBadAccess;
-    }
-
-    term *tuple = NULL;
-    size_t count;
-    Popcorn2EtsStatus status = ets_multimap_lookup(table->multimap, key, &tuple, &count, ctx->global);
-
-    bool insert_default = (count == 0);
-
-    if (insert_default && term_is_invalid_term(default_tuple)) {
-        SMP_UNLOCK(table);
-        return Popcorn2EtsTupleNotExists;
-    }
-
-    if (insert_default) {
-        if (term_get_tuple_arity(default_tuple) <= table->key_index) {
-            SMP_UNLOCK(table);
-            return Popcorn2EtsBadEntry;
-        }
-        tuple = &default_tuple;
-    }
-
-    size_t tuple_size = memory_estimate_usage(*tuple);
-
-    if (UNLIKELY(memory_ensure_free_opt(ctx, tuple_size, MEMORY_NO_GC) != MEMORY_GC_OK)) {
-        SMP_UNLOCK(table);
-        return Popcorn2EtsAllocationError;
-    }
-
-    term to_insert = memory_copy_term_tree(&ctx->heap, *tuple);
-
-    if (insert_default) {
-        term_put_tuple_element(to_insert, (uint32_t) table->key_index, key);
+        return result;
     }
 
     if (term_is_tuple(element_spec)) {
@@ -334,11 +304,11 @@ Popcorn2EtsStatus popcorn2_ets_update_element(
         }
     }
 
-    status = ets_multimap_insert(table->multimap, &to_insert, 1, ctx->global);
+    result = ets_multimap_insert(table->multimap, &to_insert, 1, ctx->global);
 
     SMP_UNLOCK(table);
 
-    return status;
+    return result;
 }
 
 Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Context *ctx)

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -96,7 +96,14 @@ static Popcorn2EtsStatus lookup_select(
     size_t index,
     term *ret,
     Context *ctx);
+static Popcorn2EtsStatus prepare_update(
+    struct Popcorn2EtsTable *table,
+    term key,
+    term default_tuple,
+    term *to_insert,
+    Context *ctx);
 static bool apply_spec(term tuple, term spec, size_t key_index);
+static bool apply_opt(term tuple, term opt, avm_int_t *ret, size_t key_index);
 
 void popcorn2_ets_init(Popcorn2Ets *ets)
 {
@@ -354,6 +361,108 @@ Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Conte
 
     SMP_UNLOCK(table);
 
+    return result;
+}
+
+Popcorn2EtsStatus popcorn2_ets_update_counter(
+    term name_or_ref,
+    term key,
+    term operation,
+    term default_tuple,
+    term *ret,
+    Context *ctx)
+{
+    struct Popcorn2EtsTable *table = get_table(
+        &ctx->global->popcorn2_ets,
+        name_or_ref,
+        ctx->process_id,
+        TableAccessWrite);
+
+    if (table == NULL) {
+        return Popcorn2EtsBadAccess;
+    }
+
+    term to_insert;
+    Popcorn2EtsStatus result = prepare_update(table, key, default_tuple, &to_insert, ctx);
+    if (result != Popcorn2EtsOk) {
+        goto cleanup;
+    }
+
+    if (term_is_integer(operation)) {
+        term value = term_get_tuple_element(to_insert, (uint32_t) table->key_index + 1);
+
+        if (!term_is_integer(value)) {
+            result = Popcorn2EtsBadEntry;
+            goto cleanup;
+        }
+
+        avm_int_t current = term_to_int(value);
+        avm_int_t delta = term_to_int(operation);
+        term new_value = term_from_int(current + delta);
+
+        term_put_tuple_element(to_insert, (uint32_t) table->key_index + 1, new_value);
+
+        *ret = new_value;
+    } else if (term_is_tuple(operation)) {
+        avm_int_t value;
+        if (!apply_opt(to_insert, operation, &value, table->key_index)) {
+            result = Popcorn2EtsBadEntry;
+            goto cleanup;
+        }
+        *ret = term_from_int(value);
+    } else if (term_is_list(operation)) {
+        size_t num_ops = 0;
+        for (term iter = operation; !term_is_nil(iter); iter = term_get_list_tail(iter)) {
+            if (!term_is_list(iter)) {
+                result = Popcorn2EtsBadEntry;
+                goto cleanup;
+            }
+            num_ops++;
+        }
+
+        if (num_ops == 0) {
+            *ret = term_nil();
+            result = Popcorn2EtsOk;
+            goto cleanup;
+        }
+
+        if (UNLIKELY(memory_ensure_free_opt(ctx, num_ops * CONS_SIZE, MEMORY_NO_GC) != MEMORY_GC_OK)) {
+            result = Popcorn2EtsAllocationError;
+            goto cleanup;
+        }
+
+        avm_int_t *values = malloc(sizeof(avm_int_t) * num_ops);
+        if (IS_NULL_PTR(values)) {
+            result = Popcorn2EtsAllocationError;
+            goto cleanup;
+        }
+
+        size_t i = 0;
+        for (term iter = operation; !term_is_nil(iter); iter = term_get_list_tail(iter), i++) {
+            term spec = term_get_list_head(iter);
+            if (!apply_opt(to_insert, spec, &values[i], table->key_index)) {
+                free(values);
+                result = Popcorn2EtsBadEntry;
+                goto cleanup;
+            }
+        }
+
+        term list = term_nil();
+        for (size_t j = num_ops; j > 0; j--) {
+            list = term_list_prepend(term_from_int(values[j - 1]), list, &ctx->heap);
+        }
+        free(values);
+
+        *ret = list;
+    } else {
+        result = Popcorn2EtsBadEntry;
+        goto cleanup;
+    }
+
+    result = ets_multimap_insert(table->multimap, &to_insert, 1, ctx->global);
+
+cleanup:
+    SMP_UNLOCK(table);
     return result;
 }
 
@@ -683,6 +792,49 @@ static Popcorn2EtsStatus lookup_select(
     return Popcorn2EtsOk;
 }
 
+static Popcorn2EtsStatus prepare_update(
+    struct Popcorn2EtsTable *table,
+    term key,
+    term default_tuple,
+    term *to_insert,
+    Context *ctx)
+{
+    if (table->type != Popcorn2EtsTableSet) {
+        return Popcorn2EtsBadAccess;
+    }
+
+    term *tuple = NULL;
+    size_t count;
+    Popcorn2EtsStatus result = ets_multimap_lookup(table->multimap, key, &tuple, &count, ctx->global);
+
+    bool insert_default = (count == 0);
+
+    if (insert_default && term_is_invalid_term(default_tuple)) {
+        return Popcorn2EtsTupleNotExists;
+    }
+
+    if (insert_default) {
+        if (term_get_tuple_arity(default_tuple) <= table->key_index) {
+            return Popcorn2EtsBadEntry;
+        }
+        tuple = &default_tuple;
+    }
+
+    size_t tuple_size = memory_estimate_usage(*tuple);
+
+    if (UNLIKELY(memory_ensure_free_opt(ctx, tuple_size, MEMORY_NO_GC) != MEMORY_GC_OK)) {
+        return Popcorn2EtsAllocationError;
+    }
+
+    *to_insert = memory_copy_term_tree(&ctx->heap, *tuple);
+
+    if (insert_default) {
+        term_put_tuple_element(*to_insert, (uint32_t) table->key_index, key);
+    }
+
+    return Popcorn2EtsOk;
+}
+
 static bool apply_spec(term tuple, term spec, size_t key_index)
 {
     if (!term_is_tuple(spec) || term_get_tuple_arity(spec) != 2) {
@@ -707,5 +859,61 @@ static bool apply_spec(term tuple, term spec, size_t key_index)
     }
 
     term_put_tuple_element(tuple, (uint32_t) index, value);
+    return true;
+}
+
+static bool apply_opt(term tuple, term opt, avm_int_t *ret, size_t key_index)
+{
+    if (!term_is_tuple(opt)) {
+        return false;
+    }
+
+    int arity = term_get_tuple_arity(opt);
+
+    if (arity != 2 && arity != 4) {
+        return false;
+    }
+
+    term pos = term_get_tuple_element(opt, 0);
+    term incr = term_get_tuple_element(opt, 1);
+
+    if (!term_is_integer(pos) || !term_is_integer(incr)) {
+        return false;
+    }
+
+    avm_int_t index = term_to_int(pos) - 1;
+    if (index < 0 || (size_t) index >= term_get_tuple_arity(tuple) || (size_t) index == key_index) {
+        return false;
+    }
+
+    term value = term_get_tuple_element(tuple, (uint32_t) index);
+
+    if (!term_is_integer(value)) {
+        return false;
+    }
+
+    avm_int_t current = term_to_int(value);
+    avm_int_t delta = term_to_int(incr);
+    avm_int_t new_value = current + delta;
+
+    if (arity == 4) {
+        term threshold = term_get_tuple_element(opt, 2);
+        term setvalue = term_get_tuple_element(opt, 3);
+
+        if (!term_is_integer(threshold) || !term_is_integer(setvalue)) {
+            return false;
+        }
+
+        avm_int_t thresh = term_to_int(threshold);
+        avm_int_t setval = term_to_int(setvalue);
+
+        if ((delta >= 0 && new_value > thresh) || (delta < 0 && new_value < thresh)) {
+            new_value = setval;
+        }
+    }
+
+    term_put_tuple_element(tuple, index, term_from_int(new_value));
+    *ret = new_value;
+
     return true;
 }

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -426,6 +426,8 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
         }
 
         term list = term_nil();
+
+        assert(num_ops >= 1);
         for (size_t j = num_ops; j > 0; j--) {
             list = term_list_prepend(term_from_int(values[j - 1]), list, &ctx->heap);
         }

--- a/src/libAtomVM/popcorn/popcorn_ets2.h
+++ b/src/libAtomVM/popcorn/popcorn_ets2.h
@@ -84,7 +84,7 @@ Popcorn2EtsStatus popcorn2_ets_lookup(term name_or_ref, term key, term *ret, Con
 Popcorn2EtsStatus popcorn2_ets_lookup_element(term name_or_ref, term key, size_t index, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_insert(term name_or_ref, term entry, bool new, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_update_element(term name_or_ref, term key, term element_spec, term default_tuple, Context *ctx);
-Popcorn2EtsStatus popcorn2_ets_update_counter(term name_or_ref, term key, term operation, term default_tuple, term *ret, Context *ctx);
+Popcorn2EtsStatus popcorn2_ets_update_counter(term name_or_ref, term key, term op, term default_tuple, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete(term name_or_ref, term key, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete_table(term name_or_ref, Context *ctx);

--- a/src/libAtomVM/popcorn/popcorn_ets2.h
+++ b/src/libAtomVM/popcorn/popcorn_ets2.h
@@ -59,7 +59,8 @@ typedef enum Popcorn2EtsStatus
     Popcorn2EtsBadEntry,
     Popcorn2EtsBadAccess,
     Popcorn2EtsBadIndex,
-    Popcorn2EtsAllocationError
+    Popcorn2EtsAllocationError,
+    Popcorn2EtsOverflow
 } Popcorn2EtsStatus;
 
 typedef struct Popcorn2Ets

--- a/src/libAtomVM/popcorn/popcorn_ets2.h
+++ b/src/libAtomVM/popcorn/popcorn_ets2.h
@@ -84,6 +84,7 @@ Popcorn2EtsStatus popcorn2_ets_lookup(term name_or_ref, term key, term *ret, Con
 Popcorn2EtsStatus popcorn2_ets_lookup_element(term name_or_ref, term key, size_t index, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_insert(term name_or_ref, term entry, bool new, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_update_element(term name_or_ref, term key, term element_spec, term default_tuple, Context *ctx);
+Popcorn2EtsStatus popcorn2_ets_update_counter(term name_or_ref, term key, term operation, term default_tuple, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete(term name_or_ref, term key, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete_table(term name_or_ref, Context *ctx);

--- a/src/libAtomVM/popcorn/popcorn_nifs.c
+++ b/src/libAtomVM/popcorn/popcorn_nifs.c
@@ -765,6 +765,8 @@ static term nif_ets_update_counter(Context *ctx, int argc, term argv[])
             RAISE_ERROR(BADARG_ATOM);
         case Popcorn2EtsAllocationError:
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
+        case Popcorn2EtsOverflow:
+            RAISE_ERROR(OVERFLOW_ATOM);
         default:
             AVM_ABORT();
     }

--- a/src/libAtomVM/popcorn/popcorn_nifs.c
+++ b/src/libAtomVM/popcorn/popcorn_nifs.c
@@ -740,26 +740,30 @@ static term nif_ets_take(Context *ctx, int argc, term argv[])
 
 static term nif_ets_update_counter(Context *ctx, int argc, term argv[])
 {
-    term ref = argv[0];
-    VALIDATE_VALUE(ref, is_ets_table_id);
+    assert(argc == 3 || argc == 4);
 
+    term name_or_ref = argv[0];
     term key = argv[1];
     term operation = argv[2];
-    term default_value = term_invalid_term();
+   
+    term default_tuple = term_invalid_term();
     if (argc == 4) {
-        default_value = argv[3];
-        VALIDATE_VALUE(default_value, term_is_tuple);
-        term_put_tuple_element(default_value, 0, key);
+        default_tuple = argv[3];
+        VALIDATE_VALUE(default_tuple, term_is_tuple);
     }
+
     term ret = term_invalid_term();
-    PopcornEtsErrorCode result = popcorn_ets_update_counter(ref, key, operation, default_value, &ret, ctx);
+
+    Popcorn2EtsStatus result = popcorn2_ets_update_counter(name_or_ref, key, operation, default_tuple, &ret, ctx);
+
     switch (result) {
-        case PopcornEtsOk:
+        case Popcorn2EtsOk:
             return ret;
-        case PopcornEtsBadAccess:
-        case PopcornEtsBadEntry:
+        case Popcorn2EtsBadAccess:
+        case Popcorn2EtsBadEntry:
+        case Popcorn2EtsTupleNotExists:
             RAISE_ERROR(BADARG_ATOM);
-        case PopcornEtsAllocationFailure:
+        case Popcorn2EtsAllocationError:
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             AVM_ABORT();

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -37,8 +37,8 @@ start() ->
     ok = isolated(fun test_delete_object/0),
     ok = isolated(fun test_lookup_element/0),
     ok = isolated(fun test_update_element/0),
+    ok = isolated(fun test_update_counter/0),
     ok = isolated(fun test_take/0),
-    % ok = isolated(fun test_update_counter/0),
     0.
 
 test_ets_new() ->
@@ -613,36 +613,126 @@ test_take() ->
     ok.
 
 test_update_counter() ->
-    T = ets:new(test, []),
-    true = ets:insert(T, {key, 10, 20, 30}),
-    % Increment
-    15 = ets:update_counter(T, key, 5),
-    10 = ets:update_counter(T, key, -5),
-    % {Position, Increment}
-    25 = ets:update_counter(T, key, {3, 5}),
-    20 = ets:update_counter(T, key, {3, -5}),
-    % {Position, Increment, Threshold, SetValue}
-    31 = ets:update_counter(T, key, {4, 10, 39, 31}),
-    30 = ets:update_counter(T, key, {4, -10, 30, 30}),
+    TableWithTuples =
+        fun (Keypos, Tuples) ->
+            T = ets:new(test, [set, {keypos, Keypos}]),
+            true = ets:insert(T, Tuples),
+            T
+        end,
 
-    TErr = ets:new(test, []),
-    true = ets:insert(TErr, {key, 0, not_number}),
-    true = ets:insert(TErr, {not_number, ok}),
-    assert_badarg(fun() -> ets:update_counter(TErr, none, 10) end),
-    assert_badarg(fun() -> ets:update_counter(TErr, not_number, 10) end),
-    assert_badarg(fun() -> ets:update_counter(TErr, not_number, {1, 10}) end),
-    assert_badarg(fun() -> ets:update_counter(TErr, not_number, {1, 10, 100, 0}) end),
-    assert_badarg(fun() -> ets:update_counter(TErr, key, {0, 10}) end),
-    assert_badarg(fun() -> ets:update_counter(TErr, key, {-1, 10}) end),
-    assert_badarg(fun() -> ets:update_counter(TErr, key, {1, 10}) end),
+    % Increment
+    S1 = TableWithTuples(1, {key, 10, not_number, 30}),
+    15 = ets:update_counter(S1, key, 5),
+    [{key, 15, not_number, 30}] = ets:lookup(S1, key),
+
+    S2 = TableWithTuples(3, {not_number, 20, key, 30}),
+    -5 = ets:update_counter(S2, key, -35),
+    [{not_number, 20, key, -5}] = ets:lookup(S2, key),
+
+    % {Position, Increment}
+    S3 = TableWithTuples(1, {key, 10, 20, not_number}),
+    25 = ets:update_counter(S3, key, {3, 5}),
+    [{key, 10, 25, not_number}] = ets:lookup(S3, key),
+
+    S4 = TableWithTuples(1, {key, 10, not_number, 30}),
+    0 = ets:update_counter(S4, key, {2, -10}),
+    [{key, 0, not_number, 30}] = ets:lookup(S4, key),
+
+    % []
+    S5 = TableWithTuples(1, {key, 10, not_number, 30}),
+    [] = ets:update_counter(S5, key, []),
+    [{key, 10, not_number, 30}] = ets:lookup(S5, key),
+
+    % [{Position, Increment}, ...]
+    S6 = TableWithTuples(1, {key, 10, 20, not_number}),
+    [0, 5, 30] = ets:update_counter(S6, key, [{2, -10}, {2, 5}, {3, 10}]),
+    [{key, 5, 30, not_number}] = ets:lookup(S6, key),
+
+    % {Position, Increment, Threshold, SetValue}
+    S7 = TableWithTuples(1, {key, not_number, 20, 30}),
+    31 = ets:update_counter(S7, key, {4, 10, 39, 31}),
+    [{key, not_number, 20, 31}] = ets:lookup(S7, key),
+
+    S8 = TableWithTuples(1, {key, 10, not_number, 30}),
+    29 = ets:update_counter(S8, key, {4, -10, 21, 29}),
+    [{key, 10, not_number, 29}] = ets:lookup(S8, key),
+
+    % [{Position, Increment, Threshold, SetValue}, ...]
+    S9 = TableWithTuples(1, {key, 10, 20, not_number}),
+    [20, 31, 26] = ets:update_counter(S9, key,
+        [{2, 10, 20, 21}, {2, 10, 29, 31}, {3, 5, 24, 26}]),
+    [{key, 31, 26, not_number}] = ets:lookup(S9, key),
+
+    % Default object
+    S10 = TableWithTuples(1, {key, 10, 20, not_number}),
+    15 = ets:update_counter(S10, key_not_exist, {2, 5}, {key, 10, 20, 30}),
+    [{key, 10, 20, not_number}] = ets:lookup(S10, key),
+    [{key_not_exist, 15, 20, 30}] = ets:lookup(S10, key_not_exist),
+
+    % Badargs
+
+    % The table type is not set
+    TErrBag = ets:new(test, [bag]),
+    TErrDuplBag = ets:new(test, [duplicate_bag]),
+    assert_badarg(fun() -> ets:update_counter(TErrBag, key, 10) end),
+    assert_badarg(fun() -> ets:update_counter(TErrDuplBag, key, 10) end),
+
+    TErr = TableWithTuples(2, {0, key, not_number}),
+
+    % Pos > KeyPos
+    TErrLastKey = TableWithTuples(2, {0, key}),
+    assert_badarg(fun() -> ets:update_counter(TErrLastKey, key, 10) end),
+
+    % No object with the correct key exists and no default object was supplied
+    assert_badarg(fun() -> ets:update_counter(TErr, key_not_exist, 10) end),
+    assert_badarg(fun() -> ets:update_counter(TErr, key_not_exist, {1, 10}) end),
+    assert_badarg(fun() -> ets:update_counter(TErr, key_not_exist, {1, 10, 20, 30}) end),
+
+    % The object has the wrong arity
+    % Pos > TupleArity
+    assert_badarg(fun() -> ets:update_counter(TErr, key, {4, 10}) end),
+
+    % Default object arity < KeyPos
+    % NOTE: This fails on OTP, see https://github.com/erlang/otp/issues/10603
+    assert_badarg(fun() -> ets:update_counter(TErr, key_not_exist, [{1, 10}], {10}) end),
+
+    % Any field from the default object that is updated is not an integer
+    assert_badarg(fun() -> ets:update_counter(
+        TErr, key_not_exist, {2, 10}, {0, key, not_number}) end),
+    assert_badarg(fun() -> ets:update_counter(
+        TErr, key_not_exist, {3, 10}, {0, key, not_number}) end),
+
+    % The element to update is not an integer
+    assert_badarg(fun() -> ets:update_counter(TErr, key, 10) end),
     assert_badarg(fun() -> ets:update_counter(TErr, key, {3, 10}) end),
+    assert_badarg(fun() -> ets:update_counter(TErr, key, [{1, 10}, {3, 10}]) end),
+
+    % The element to update is also the key
+    assert_badarg(fun() -> ets:update_counter(TErr, key, {2, 10}) end),
+    assert_badarg(fun() -> ets:update_counter(TErr, key, [{1, 10}, {2, 10}]) end),
+
+    TErrIntKey = TableWithTuples(2, {10, 0}),
+    assert_badarg(fun() -> ets:update_counter(TErrIntKey, 0, {2, 10}) end),
+    assert_badarg(fun() -> ets:update_counter(TErrIntKey, 0, [{1, 10}, {2, 10}]) end),
+    [{10, 0}] = ets:lookup(TErrIntKey, 0),
+
+    Key = 10,
+    assert_badarg(fun() -> ets:update_counter(
+        TErr, key_not_exist, {2, 10}, {0, Key, not_number}) end),
+
+    % Any of Pos, Incr, Threshold, or SetValue is not an integer
     assert_badarg(fun() -> ets:update_counter(TErr, key, not_number) end),
+    assert_badarg(fun() -> ets:update_counter(TErr, key, {1, not_number}) end),
     assert_badarg(fun() -> ets:update_counter(TErr, key, {not_number, 10}) end),
-    assert_badarg(fun() -> ets:update_counter(TErr, key, {2, not_number}) end),
-    assert_badarg(fun() -> ets:update_counter(TErr, key, {not_number, 10, 100, 0}) end),
-    assert_badarg(fun() -> ets:update_counter(TErr, key, {2, not_number, 100, 0}) end),
-    assert_badarg(fun() -> ets:update_counter(TErr, key, {2, 10, not_number, 0}) end),
-    assert_badarg(fun() -> ets:update_counter(TErr, key, {2, 10, 100, not_number}) end),
+    assert_badarg(fun() -> ets:update_counter(TErr, key, [{1, 10}, {1, not_number}]) end),
+    assert_badarg(fun() -> ets:update_counter(TErr, key, [{1, 10}, {not_number, 10}]) end),
+    assert_badarg(fun() -> ets:update_counter(TErr, key, {1, 10, not_number, 30}) end),
+    assert_badarg(fun() -> ets:update_counter(TErr, key, {1, 10, 20, not_number}) end),
+    assert_badarg(fun() -> ets:update_counter(TErr, key, [{1, 10, 20, 30}, {1, 10, not_number, 30}]) end),
+    assert_badarg(fun() -> ets:update_counter(TErr, key, [{1, 10, 20, 30}, {1, 10, 20, not_number}]) end),
+
+    [{0, key, not_number}] = ets:lookup(TErr, key),
+
     ok.
 
 %%-----------------------------------------------------------------------------

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -509,22 +509,25 @@ test_update_element() ->
             T
         end,
 
+    % {Position, Value}
     S1 = TableWithTuples(set, {key, value1, value2}),
     true = ets:update_element(S1, key, {2, new_value1}),
     [{key, new_value1, value2}] = ets:lookup(S1, key),
 
     S2 = TableWithTuples(set, {key, value1, value2}),
-    false = ets:update_element(S2, key_not_exist, {2, new_value1}),
-    [{key, value1, value2}] = ets:lookup(S2, key), 
+    true = ets:update_element(S2, key, {3, new_value2}),
+    [{key, value1, new_value2}] = ets:lookup(S2, key),
 
     S3 = TableWithTuples(set, {key, value1, value2}),
-    true = ets:update_element(S3, key, {3, new_value2}),
-    [{key, value1, new_value2}] = ets:lookup(S3, key),
+    false = ets:update_element(S3, key_not_exist, {2, new_value1}),
+    [{key, value1, value2}] = ets:lookup(S3, key),
 
+    % [{Position, Value}, ...]
     S4 = TableWithTuples(set, {key, value1, value2}),
     true = ets:update_element(S4, key, [{3, new_value2}, {2, new_value1}, {3, new_last_value2}]),
     [{key, new_value1, new_last_value2}] = ets:lookup(S4, key),
 
+    % Default object
     S5 = TableWithTuples(set, {key, value1, value2}),
     true = ets:update_element(S5, key_not_exist, {2, new_value1}, {key, value1, value2}),
     [{key_not_exist, new_value1, value2}] = ets:lookup(S5, key_not_exist),
@@ -534,13 +537,14 @@ test_update_element() ->
         [{2, new_value1}, {3, new_value2}, {3, new_last_value2}], {key, value1, value2}),
     [{key_not_exist, new_value1, new_last_value2}] = ets:lookup(S6, key_not_exist),
 
-    % badargs
+    % Badargs
+
     TErr = ets:new(test, [set, {keypos, 3}]),
     true = ets:insert(TErr, {value1, value2, key}),
 
     OkDefault = {value, value, value},
 
-    % incompatible table types
+    % The table type is not set
     TErrBag = ets:new(test, [bag]),
     TErrDuplBag = ets:new(test, [duplicate_bag]),
     assert_badarg(fun() -> ets:update_element(TErrBag, key, {1, value}) end),
@@ -566,49 +570,13 @@ test_update_element() ->
         TErr, key_not_exist, [{1, pos_ok}, {4, pos_past}], OkDefault) end),
 
     % Default object arity < KeyPos
+    % NOTE: This fails on OTP, see https://github.com/erlang/otp/issues/10603
     assert_badarg(fun() -> ets:update_element(TErr, key_not_exist, {1, pos_ok}, {value}) end),
     assert_badarg(fun() -> ets:update_element(
         TErr, key_not_exist, [{1, pos_ok}, {2, pos_ok}], {value, value}) end),
 
     [{value1, value2, key}] = ets:lookup(TErr, key),
     [] = ets:lookup(TErr, key_not_exist),
-
-    ok.
-
-test_take() ->
-    TableWithTuples =
-        fun (Type, Tuples) ->
-            T = ets:new(test, [Type]),
-            true = ets:insert(T, Tuples),
-            T
-        end,
-
-    % set
-    S1 = TableWithTuples(set, []),
-    [] = ets:take(S1, key_not_exist),
-
-    S2 = TableWithTuples(set, [{key, value}, {key2, value2}]),
-    [{key, value}] = ets:take(S2, key),
-    [] = ets:lookup(S2, key),
-    [{key2, value2}] = ets:lookup(S2, key2),
-
-    % bag
-    B1 = TableWithTuples(bag, []),
-    [] = ets:take(B1, key_not_exist),
-
-    B2 = TableWithTuples(bag, [{key, value}, {key, value2}, {key2, value3}]),
-    [{key, value}, {key, value2}] = ets:take(B2, key),
-    [] = ets:lookup(B2, key),
-    [{key2, value3}] = ets:lookup(B2, key2),
-
-    % duplicate_bag
-    DB1 = TableWithTuples(duplicate_bag, []),
-    [] = ets:take(DB1, key_not_exist),
-
-    DB2 = TableWithTuples(duplicate_bag, [{key, value}, {key, value}, {key2, value2}]),
-    [{key, value}, {key, value}] = ets:take(DB2, key),
-    [] = ets:lookup(DB2, key),
-    [{key2, value2}] = ets:lookup(DB2, key2),
 
     ok.
 
@@ -732,6 +700,43 @@ test_update_counter() ->
     assert_badarg(fun() -> ets:update_counter(TErr, key, [{1, 10, 20, 30}, {1, 10, 20, not_number}]) end),
 
     [{0, key, not_number}] = ets:lookup(TErr, key),
+
+    ok.
+
+test_take() ->
+    TableWithTuples =
+        fun (Type, Tuples) ->
+            T = ets:new(test, [Type]),
+            true = ets:insert(T, Tuples),
+            T
+        end,
+
+    % set
+    S1 = TableWithTuples(set, []),
+    [] = ets:take(S1, key_not_exist),
+
+    S2 = TableWithTuples(set, [{key, value}, {key2, value2}]),
+    [{key, value}] = ets:take(S2, key),
+    [] = ets:lookup(S2, key),
+    [{key2, value2}] = ets:lookup(S2, key2),
+
+    % bag
+    B1 = TableWithTuples(bag, []),
+    [] = ets:take(B1, key_not_exist),
+
+    B2 = TableWithTuples(bag, [{key, value}, {key, value2}, {key2, value3}]),
+    [{key, value}, {key, value2}] = ets:take(B2, key),
+    [] = ets:lookup(B2, key),
+    [{key2, value3}] = ets:lookup(B2, key2),
+
+    % duplicate_bag
+    DB1 = TableWithTuples(duplicate_bag, []),
+    [] = ets:take(DB1, key_not_exist),
+
+    DB2 = TableWithTuples(duplicate_bag, [{key, value}, {key, value}, {key2, value2}]),
+    [{key, value}, {key, value}] = ets:take(DB2, key),
+    [] = ets:lookup(DB2, key),
+    [{key2, value2}] = ets:lookup(DB2, key2),
 
     ok.
 


### PR DESCRIPTION
This PR implements the `update_counter/4` function and adds some minor changes.

Minor changes:

- Simplify `popcorn2_ets_update_element` using `lookup_or_default` helper
- Improve test_ets comments and reorder test functions