### PR TITLE
Implement ETS `member/2`

### DIFF
--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -815,6 +815,9 @@ static Popcorn2EtsStatus lookup_or_default(
     size_t tuple_size = memory_estimate_usage(*tuple);
 
     if (UNLIKELY(memory_init_heap(ret_heap, tuple_size) != MEMORY_GC_OK)) {
+        if (!insert_default) {
+            free(tuple);
+        }
         return Popcorn2EtsAllocationError;
     }
 
@@ -822,6 +825,8 @@ static Popcorn2EtsStatus lookup_or_default(
 
     if (insert_default) {
         term_put_tuple_element(*ret, (uint32_t) table->key_index, key);
+    } else {
+        free(tuple);
     }
 
     return Popcorn2EtsOk;
@@ -851,6 +856,7 @@ static Popcorn2EtsStatus apply_spec(term tuple, term spec, size_t key_index)
     }
 
     term_put_tuple_element(tuple, (uint32_t) index, value);
+
     return Popcorn2EtsOk;
 }
 

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -307,6 +307,9 @@ Popcorn2EtsStatus popcorn2_ets_update_element(
                 goto cleanup;
             }
         }
+    } else {
+        result = Popcorn2EtsBadEntry;
+        goto cleanup;
     }
 
     result = ets_multimap_insert(table->multimap, &insert_tuple, 1, ctx->global);

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -816,9 +816,9 @@ static Popcorn2EtsStatus lookup_or_default(
         tuple = &default_tuple;
     }
 
-    size_t tuple_size = memory_estimate_usage(*tuple);
+    size_t size = memory_estimate_usage(*tuple) + memory_estimate_usage(key);
 
-    if (UNLIKELY(memory_init_heap(ret_heap, tuple_size) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_init_heap(ret_heap, size) != MEMORY_GC_OK)) {
         if (!insert_default) {
             free(tuple);
         }
@@ -828,6 +828,7 @@ static Popcorn2EtsStatus lookup_or_default(
     *ret = memory_copy_term_tree(ret_heap, *tuple);
 
     if (insert_default) {
+        key = memory_copy_term_tree(ret_heap, key);
         term_put_tuple_element(*ret, (uint32_t) table->key_index, key);
     } else {
         free(tuple);

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -120,7 +120,7 @@ void popcorn2_ets_destroy(Popcorn2Ets *ets, GlobalContext *global)
     synclist_destroy(&ets->ets_tables);
 }
 
-Popcorn2EtsStatus popcorn2_ets_create_table(
+Popcorn2EtsStatus popcorn2_ets_create_table_maybe_gc(
     term name,
     bool named,
     Popcorn2EtsTableType type,
@@ -196,7 +196,7 @@ Popcorn2EtsStatus popcorn2_ets_create_table(
     return Popcorn2EtsOk;
 }
 
-Popcorn2EtsStatus popcorn2_ets_lookup(term name_or_ref, term key, term *ret, Context *ctx)
+Popcorn2EtsStatus popcorn2_ets_lookup_maybe_gc(term name_or_ref, term key, term *ret, Context *ctx)
 {
     assert(ret != NULL);
 
@@ -217,7 +217,7 @@ Popcorn2EtsStatus popcorn2_ets_lookup(term name_or_ref, term key, term *ret, Con
     return result;
 }
 
-Popcorn2EtsStatus popcorn2_ets_lookup_element(term name_or_ref, term key, size_t index, term *ret, Context *ctx)
+Popcorn2EtsStatus popcorn2_ets_lookup_element_maybe_gc(term name_or_ref, term key, size_t index, term *ret, Context *ctx)
 {
     assert(ret != NULL);
 
@@ -317,7 +317,7 @@ cleanup:
     return result;
 }
 
-Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Context *ctx)
+Popcorn2EtsStatus popcorn2_ets_take_maybe_gc(term name_or_ref, term key, term *ret, Context *ctx)
 {
     struct Popcorn2EtsTable *table = get_table(
         &ctx->global->popcorn2_ets,
@@ -340,7 +340,7 @@ Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Conte
     return result;
 }
 
-Popcorn2EtsStatus popcorn2_ets_update_counter(
+Popcorn2EtsStatus popcorn2_ets_update_counter_maybe_gc(
     term name_or_ref,
     term key,
     term op,

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -41,9 +41,9 @@
 #define SMP_WRLOCK(table) smp_rwlock_wrlock(table->lock)
 #define SMP_UNLOCK(table) smp_rwlock_unlock(table->lock)
 #else
-#define SMP_RDLOCK(htable) UNUSED(htable)
-#define SMP_WRLOCK(htable) UNUSED(htable)
-#define SMP_UNLOCK(htable) UNUSED(htable)
+#define SMP_RDLOCK(table) UNUSED(table)
+#define SMP_WRLOCK(table) UNUSED(table)
+#define SMP_UNLOCK(table) UNUSED(table)
 #endif
 
 struct Popcorn2EtsTable
@@ -367,7 +367,7 @@ Popcorn2EtsStatus popcorn2_ets_update_counter(
     if (term_is_integer(op)) {
         avm_int_t index = (avm_int_t) table->key_index + 1;
 
-        if (index >= term_get_tuple_arity(insert_tuple)) {
+        if (index < 0 || index >= term_get_tuple_arity(insert_tuple)) {
             result = Popcorn2EtsBadEntry;
             goto cleanup;
         }

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -238,6 +238,30 @@ Popcorn2EtsStatus popcorn2_ets_lookup_element_maybe_gc(term name_or_ref, term ke
     return result;
 }
 
+Popcorn2EtsStatus popcorn2_ets_member(term name_or_ref, term key, Context *ctx)
+{
+    struct Popcorn2EtsTable *table = get_table(
+        &ctx->global->popcorn2_ets,
+        name_or_ref,
+        ctx->process_id,
+        TableAccessRead);
+
+    if (table == NULL) {
+        return Popcorn2EtsBadAccess;
+    }
+
+    size_t count;
+    Popcorn2EtsStatus result = ets_multimap_lookup(table->multimap, key, NULL, &count, ctx->global);
+
+    if (result == Popcorn2EtsOk && count == 0) {
+        result = Popcorn2EtsTupleNotExists;
+    }
+
+    SMP_UNLOCK(table);
+
+    return result;
+}
+
 Popcorn2EtsStatus popcorn2_ets_insert(term name_or_ref, term entry, bool as_new, Context *ctx)
 {
     struct Popcorn2EtsTable *table = get_table(

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -84,12 +84,12 @@ static void table_destroy(struct Popcorn2EtsTable *table, GlobalContext *global)
 static Popcorn2EtsStatus insert_one(
     struct Popcorn2EtsTable *table,
     term tuple,
-    bool new,
+    bool as_new,
     Context *ctx);
 static Popcorn2EtsStatus insert_many(
     struct Popcorn2EtsTable *table,
     term tuples,
-    bool new,
+    bool as_new,
     Context *ctx);
 static Popcorn2EtsStatus lookup_select_maybe_gc(
     struct Popcorn2EtsTable *table,
@@ -238,7 +238,7 @@ Popcorn2EtsStatus popcorn2_ets_lookup_element_maybe_gc(term name_or_ref, term ke
     return result;
 }
 
-Popcorn2EtsStatus popcorn2_ets_insert(term name_or_ref, term entry, bool new, Context *ctx)
+Popcorn2EtsStatus popcorn2_ets_insert(term name_or_ref, term entry, bool as_new, Context *ctx)
 {
     struct Popcorn2EtsTable *table = get_table(
         &ctx->global->popcorn2_ets,
@@ -253,9 +253,9 @@ Popcorn2EtsStatus popcorn2_ets_insert(term name_or_ref, term entry, bool new, Co
     Popcorn2EtsStatus result = Popcorn2EtsBadEntry;
 
     if (term_is_tuple(entry)) {
-        result = insert_one(table, entry, new, ctx);
+        result = insert_one(table, entry, as_new, ctx);
     } else if (term_is_list(entry)) {
-        result = insert_many(table, entry, new, ctx);
+        result = insert_many(table, entry, as_new, ctx);
     }
 
     SMP_UNLOCK(table);
@@ -620,7 +620,7 @@ static struct Popcorn2EtsTable *get_table(
 static Popcorn2EtsStatus insert_one(
     struct Popcorn2EtsTable *table,
     term tuple,
-    bool new,
+    bool as_new,
     Context *ctx)
 {
     assert(term_is_tuple(tuple));
@@ -631,7 +631,7 @@ static Popcorn2EtsStatus insert_one(
         return Popcorn2EtsBadEntry;
     }
 
-    if (new) {
+    if (as_new) {
         term key = term_get_tuple_element(tuple, table->key_index);
         size_t existing = 0;
         result = ets_multimap_lookup(table->multimap, key, NULL, &existing, ctx->global);
@@ -651,7 +651,7 @@ static Popcorn2EtsStatus insert_one(
 static Popcorn2EtsStatus insert_many(
     struct Popcorn2EtsTable *table,
     term tuples,
-    bool new,
+    bool as_new,
     Context *ctx)
 {
     assert(term_is_list(tuples));
@@ -670,7 +670,7 @@ static Popcorn2EtsStatus insert_many(
             return Popcorn2EtsBadEntry;
         }
 
-        if (new) {
+        if (as_new) {
             term key = term_get_tuple_element(tuple, table->key_index);
             size_t existing = 0;
             result = ets_multimap_lookup(table->multimap, key, NULL, &existing, ctx->global);

--- a/src/libAtomVM/popcorn/popcorn_ets2.c
+++ b/src/libAtomVM/popcorn/popcorn_ets2.c
@@ -91,10 +91,12 @@ static Popcorn2EtsStatus insert_many(
     term tuples,
     bool new,
     Context *ctx);
-static Popcorn2EtsStatus lookup_select(
+static Popcorn2EtsStatus lookup_select_maybe_gc(
     struct Popcorn2EtsTable *table,
     term key,
     size_t index,
+    size_t num_roots,
+    term *roots,
     term *ret,
     Context *ctx);
 static Popcorn2EtsStatus lookup_or_default(
@@ -208,7 +210,7 @@ Popcorn2EtsStatus popcorn2_ets_lookup(term name_or_ref, term key, term *ret, Con
         return Popcorn2EtsBadAccess;
     }
 
-    Popcorn2EtsStatus result = lookup_select(table, key, ETS_WHOLE_TUPLE, ret, ctx);
+    Popcorn2EtsStatus result = lookup_select_maybe_gc(table, key, ETS_WHOLE_TUPLE, 0, NULL, ret, ctx);
 
     SMP_UNLOCK(table);
 
@@ -229,7 +231,7 @@ Popcorn2EtsStatus popcorn2_ets_lookup_element(term name_or_ref, term key, size_t
         return Popcorn2EtsBadAccess;
     }
 
-    Popcorn2EtsStatus result = lookup_select(table, key, index, ret, ctx);
+    Popcorn2EtsStatus result = lookup_select_maybe_gc(table, key, index, 0, NULL, ret, ctx);
 
     SMP_UNLOCK(table);
 
@@ -327,7 +329,7 @@ Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Conte
         return Popcorn2EtsBadAccess;
     }
 
-    Popcorn2EtsStatus result = lookup_select(table, key, ETS_WHOLE_TUPLE, ret, ctx);
+    Popcorn2EtsStatus result = lookup_select_maybe_gc(table, key, ETS_WHOLE_TUPLE, 1, &key, ret, ctx);
 
     if (result == Popcorn2EtsOk) {
         result = ets_multimap_remove(table->multimap, key, ctx->global);
@@ -695,10 +697,12 @@ static Popcorn2EtsStatus insert_many(
     return result;
 }
 
-static Popcorn2EtsStatus lookup_select(
+static Popcorn2EtsStatus lookup_select_maybe_gc(
     struct Popcorn2EtsTable *table,
     term key,
     size_t index,
+    size_t num_roots,
+    term *roots,
     term *ret,
     Context *ctx)
 {
@@ -745,7 +749,7 @@ static Popcorn2EtsStatus lookup_select(
     }
 
     // Terms in `tuples` come from ETS heap, we need to copy them to process heap before returning.
-    if (UNLIKELY(memory_ensure_free_opt(ctx, elements_size, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
+    if (UNLIKELY(memory_ensure_free_with_roots(ctx, elements_size, num_roots, roots, MEMORY_CAN_SHRINK) != MEMORY_GC_OK)) {
         free(tuples);
         return Popcorn2EtsAllocationError;
     }

--- a/src/libAtomVM/popcorn/popcorn_ets2.h
+++ b/src/libAtomVM/popcorn/popcorn_ets2.h
@@ -83,7 +83,7 @@ void popcorn2_ets_delete_owned_tables(Popcorn2Ets *ets, int32_t process_id, Glob
 
 Popcorn2EtsStatus popcorn2_ets_lookup_maybe_gc(term name_or_ref, term key, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_lookup_element_maybe_gc(term name_or_ref, term key, size_t index, term *ret, Context *ctx);
-Popcorn2EtsStatus popcorn2_ets_insert(term name_or_ref, term entry, bool new, Context *ctx);
+Popcorn2EtsStatus popcorn2_ets_insert(term name_or_ref, term entry, bool as_new, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_update_element(term name_or_ref, term key, term element_spec, term default_tuple, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_update_counter_maybe_gc(term name_or_ref, term key, term op, term default_tuple, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_take_maybe_gc(term name_or_ref, term key, term *ret, Context *ctx);

--- a/src/libAtomVM/popcorn/popcorn_ets2.h
+++ b/src/libAtomVM/popcorn/popcorn_ets2.h
@@ -83,6 +83,7 @@ void popcorn2_ets_delete_owned_tables(Popcorn2Ets *ets, int32_t process_id, Glob
 
 Popcorn2EtsStatus popcorn2_ets_lookup_maybe_gc(term name_or_ref, term key, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_lookup_element_maybe_gc(term name_or_ref, term key, size_t index, term *ret, Context *ctx);
+Popcorn2EtsStatus popcorn2_ets_member(term name_or_ref, term key, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_insert(term name_or_ref, term entry, bool as_new, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_update_element(term name_or_ref, term key, term element_spec, term default_tuple, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_update_counter_maybe_gc(term name_or_ref, term key, term op, term default_tuple, term *ret, Context *ctx);

--- a/src/libAtomVM/popcorn/popcorn_ets2.h
+++ b/src/libAtomVM/popcorn/popcorn_ets2.h
@@ -71,7 +71,7 @@ typedef struct Popcorn2Ets
 void popcorn2_ets_init(Popcorn2Ets *ets);
 void popcorn2_ets_destroy(Popcorn2Ets *ets, GlobalContext *global);
 
-Popcorn2EtsStatus popcorn2_ets_create_table(
+Popcorn2EtsStatus popcorn2_ets_create_table_maybe_gc(
     term name,
     bool named,
     Popcorn2EtsTableType type,
@@ -81,12 +81,12 @@ Popcorn2EtsStatus popcorn2_ets_create_table(
     Context *ctx);
 void popcorn2_ets_delete_owned_tables(Popcorn2Ets *ets, int32_t process_id, GlobalContext *global);
 
-Popcorn2EtsStatus popcorn2_ets_lookup(term name_or_ref, term key, term *ret, Context *ctx);
-Popcorn2EtsStatus popcorn2_ets_lookup_element(term name_or_ref, term key, size_t index, term *ret, Context *ctx);
+Popcorn2EtsStatus popcorn2_ets_lookup_maybe_gc(term name_or_ref, term key, term *ret, Context *ctx);
+Popcorn2EtsStatus popcorn2_ets_lookup_element_maybe_gc(term name_or_ref, term key, size_t index, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_insert(term name_or_ref, term entry, bool new, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_update_element(term name_or_ref, term key, term element_spec, term default_tuple, Context *ctx);
-Popcorn2EtsStatus popcorn2_ets_update_counter(term name_or_ref, term key, term op, term default_tuple, term *ret, Context *ctx);
-Popcorn2EtsStatus popcorn2_ets_take(term name_or_ref, term key, term *ret, Context *ctx);
+Popcorn2EtsStatus popcorn2_ets_update_counter_maybe_gc(term name_or_ref, term key, term op, term default_tuple, term *ret, Context *ctx);
+Popcorn2EtsStatus popcorn2_ets_take_maybe_gc(term name_or_ref, term key, term *ret, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete(term name_or_ref, term key, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete_table(term name_or_ref, Context *ctx);
 Popcorn2EtsStatus popcorn2_ets_delete_object(term name_or_ref, term tuple, Context *ctx);

--- a/src/libAtomVM/popcorn/popcorn_ets_multimap.c
+++ b/src/libAtomVM/popcorn/popcorn_ets_multimap.c
@@ -113,11 +113,6 @@ Popcorn2EtsStatus ets_multimap_lookup(
         return Popcorn2EtsOk;
     }
 
-    if (*count == 0) {
-        *tuples = NULL;
-        return Popcorn2EtsOk;
-    }
-
     *tuples = malloc(sizeof(term) * (*count));
     if (IS_NULL_PTR(*tuples)) {
         return Popcorn2EtsAllocationError;
@@ -368,10 +363,6 @@ static Popcorn2EtsStatus node_find(
 
     uint32_t idx = hash_term(key, global) % NUM_BUCKETS;
     EtsMultimapNode *node = multimap->buckets[idx];
-
-    if (node == NULL) {
-        return Popcorn2EtsOk;
-    }
 
     while (node) {
         TermCompareResult result = term_compare(key, node_key(multimap, node), TermCompareExact, global);

--- a/src/libAtomVM/popcorn/popcorn_ets_multimap.c
+++ b/src/libAtomVM/popcorn/popcorn_ets_multimap.c
@@ -331,13 +331,13 @@ Popcorn2EtsStatus ets_multimap_remove_tuple(
     if (node->entries == NULL) {
         uint32_t idx = hash_term(key, global) % NUM_BUCKETS;
 
-        EtsMultimapNode *prev = NULL;
-        for (EtsMultimapNode *iter = multimap->buckets[idx]; iter != NULL; prev = iter, iter = iter->next) {
+        EtsMultimapNode *prev_node = NULL;
+        for (EtsMultimapNode *iter = multimap->buckets[idx]; iter != NULL; prev_node = iter, iter = iter->next) {
             if (iter == node) {
-                if (prev == NULL) {
+                if (prev_node == NULL) {
                     multimap->buckets[idx] = iter->next;
                 } else {
-                    prev->next = iter->next;
+                    prev_node->next = iter->next;
                 }
                 break;
             }

--- a/src/libAtomVM/popcorn/popcorn_ets_multimap.c
+++ b/src/libAtomVM/popcorn/popcorn_ets_multimap.c
@@ -309,7 +309,8 @@ Popcorn2EtsStatus ets_multimap_remove_tuple(
     }
 
     EtsMultimapEntry *prev = NULL;
-    for (EtsMultimapEntry *iter = node->entries; iter != NULL; prev = iter, iter = iter->next) {
+    for (EtsMultimapEntry *iter = node->entries; iter != NULL; iter = iter->next) {
+        bool removed = false;
         for (size_t i = 0; i < count; i++) {
             if (iter == to_remove[i]) {
                 if (prev == NULL) {
@@ -317,7 +318,12 @@ Popcorn2EtsStatus ets_multimap_remove_tuple(
                 } else {
                     prev->next = iter->next;
                 }
+                removed = true;
+                break;
             }
+        }
+        if (!removed) {
+            prev = iter;
         }
     }
 

--- a/src/libAtomVM/popcorn/popcorn_ets_multimap.c
+++ b/src/libAtomVM/popcorn/popcorn_ets_multimap.c
@@ -196,6 +196,8 @@ Popcorn2EtsStatus ets_multimap_insert(
             }
 
             if (exists) {
+                entry_delete(entry, global);
+                entries[i] = NULL;
                 continue;
             }
         }
@@ -426,7 +428,9 @@ static void insert_revert(
     }
 
     for (size_t i = 0; i < count; i++) {
-        entry_delete(entries[i], global);
+        if (entries[i] != NULL) {
+            entry_delete(entries[i], global);
+        }
     }
 }
 
@@ -534,5 +538,6 @@ static void node_delete(EtsMultimapNode *node, GlobalContext *global)
 static void entry_delete(EtsMultimapEntry *entry, GlobalContext *global)
 {
     memory_destroy_heap(entry->heap, global);
+    free(entry->heap);
     free(entry);
 }

--- a/src/libAtomVM/popcorn/popcorn_ets_multimap.h
+++ b/src/libAtomVM/popcorn/popcorn_ets_multimap.h
@@ -18,8 +18,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
 
-#ifndef _POPCORN_ETS_MULTIMAP_H_
-#define _POPCORN_ETS_MULTIMAP_H_
+#ifndef _POPCORN2_ETS_MULTIMAP_H_
+#define _POPCORN2_ETS_MULTIMAP_H_
 
 #include "../globalcontext.h"
 #include "../term.h"
@@ -89,7 +89,7 @@ void ets_multimap_delete(EtsMultimap *multimap, GlobalContext *global);
  * @note The returned tuples are ordered in reverse insertion order
  *       (most recently added elements first).
  * @warning The caller is responsible for freeing the memory pointed to by `tuples`
- *          using `free()`. When count is zero, memory is not allocated and `tuples` is set to NULL.
+ *          using `free()`. When count is zero, memory is not allocated.
  */
 Popcorn2EtsStatus ets_multimap_lookup(
     EtsMultimap *multimap,
@@ -144,4 +144,4 @@ Popcorn2EtsStatus ets_multimap_remove_tuple(
 }
 #endif
 
-#endif // _POPCORN_ETS_MULTIMAP_H_
+#endif // _POPCORN2_ETS_MULTIMAP_H_

--- a/src/libAtomVM/popcorn/popcorn_ets_multimap_hash.h
+++ b/src/libAtomVM/popcorn/popcorn_ets_multimap_hash.h
@@ -78,7 +78,7 @@ static uint32_t hash_float(term t, int32_t h, GlobalContext *global)
     UNUSED(global);
     avm_float_t f = term_to_float(t);
     uint8_t *data = (uint8_t *) &f;
-    size_t len = sizeof(float);
+    size_t len = sizeof(avm_float_t);
     for (size_t i = 0; i < len; ++i) {
         h = h * LARGE_PRIME_FLOAT + data[i];
     }
@@ -204,11 +204,11 @@ static uint32_t hash_term_incr(term t, int32_t h, GlobalContext *global)
                 h = h * LARGE_PRIME_LIST;
                 break;
             } else if (!term_is_list(t)) {
-                h = h * LARGE_PRIME_LIST + hash_term_incr(elt, h, global);
+                h = h * LARGE_PRIME_LIST + hash_term_incr(t, h, global);
                 break;
             }
         }
-        return h * LARGE_PRIME_TUPLE;
+        return h * LARGE_PRIME_LIST;
     } else if (term_is_map(t)) {
         size_t size = term_get_map_size(t);
         for (size_t i = 0; i < size; ++i) {

--- a/src/libAtomVM/popcorn/popcorn_nifs.c
+++ b/src/libAtomVM/popcorn/popcorn_nifs.c
@@ -689,21 +689,25 @@ static term nif_ets_lookup(Context *ctx, int argc, term argv[])
 
 static term nif_ets_member(Context *ctx, int argc, term argv[])
 {
-    UNUSED(argc);
+    assert(argc == 2);
 
-    term ref = argv[0];
-    VALIDATE_VALUE(ref, is_ets_table_id);
-
+    term name_or_ref = argv[0];
     term key = argv[1];
 
+    VALIDATE_VALUE(name_or_ref, is_ets_table_id);
+
     term ret = term_invalid_term();
-    PopcornEtsErrorCode result = popcorn_ets_lookup(ref, key, &ret, ctx);
+
+    Popcorn2EtsStatus result = popcorn2_ets_lookup(name_or_ref, key, &ret, ctx);
+
     switch (result) {
-        case PopcornEtsOk:
-            return term_is_nil(ret) ? FALSE_ATOM : TRUE_ATOM;
-        case PopcornEtsBadAccess:
+        case Popcorn2EtsOk:
+            return TRUE_ATOM;
+        case Popcorn2EtsTupleNotExists:
+            return FALSE_ATOM;
+        case Popcorn2EtsBadAccess:
             RAISE_ERROR(BADARG_ATOM);
-        case PopcornEtsAllocationFailure:
+        case Popcorn2EtsAllocationError:
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             AVM_ABORT();

--- a/src/libAtomVM/popcorn/popcorn_nifs.c
+++ b/src/libAtomVM/popcorn/popcorn_nifs.c
@@ -580,7 +580,7 @@ static term nif_ets_new(Context *ctx, int argc, term argv[])
 
     term table = term_invalid_term();
 
-    Popcorn2EtsStatus result = popcorn2_ets_create_table(
+    Popcorn2EtsStatus result = popcorn2_ets_create_table_maybe_gc(
         name,
         is_named == TRUE_ATOM,
         type,
@@ -670,7 +670,7 @@ static term nif_ets_lookup(Context *ctx, int argc, term argv[])
 
     term ret = term_invalid_term();
 
-    Popcorn2EtsStatus result = popcorn2_ets_lookup(name_or_ref, key, &ret, ctx);
+    Popcorn2EtsStatus result = popcorn2_ets_lookup_maybe_gc(name_or_ref, key, &ret, ctx);
 
     switch (result) {
         case Popcorn2EtsOk:
@@ -698,7 +698,7 @@ static term nif_ets_member(Context *ctx, int argc, term argv[])
 
     term ret = term_invalid_term();
 
-    Popcorn2EtsStatus result = popcorn2_ets_lookup(name_or_ref, key, &ret, ctx);
+    Popcorn2EtsStatus result = popcorn2_ets_lookup_maybe_gc(name_or_ref, key, &ret, ctx);
 
     switch (result) {
         case Popcorn2EtsOk:
@@ -710,6 +710,7 @@ static term nif_ets_member(Context *ctx, int argc, term argv[])
         case Popcorn2EtsAllocationError:
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
+            // unreachable
             AVM_ABORT();
     }
 }
@@ -725,7 +726,7 @@ static term nif_ets_take(Context *ctx, int argc, term argv[])
 
     term ret = term_invalid_term();
 
-    Popcorn2EtsStatus result = popcorn2_ets_take(name_or_ref, key, &ret, ctx);
+    Popcorn2EtsStatus result = popcorn2_ets_take_maybe_gc(name_or_ref, key, &ret, ctx);
 
     switch (result) {
         case Popcorn2EtsOk:
@@ -758,7 +759,7 @@ static term nif_ets_update_counter(Context *ctx, int argc, term argv[])
 
     term ret = term_invalid_term();
 
-    Popcorn2EtsStatus result = popcorn2_ets_update_counter(name_or_ref, key, operation, default_tuple, &ret, ctx);
+    Popcorn2EtsStatus result = popcorn2_ets_update_counter_maybe_gc(name_or_ref, key, operation, default_tuple, &ret, ctx);
 
     switch (result) {
         case Popcorn2EtsOk:
@@ -772,6 +773,7 @@ static term nif_ets_update_counter(Context *ctx, int argc, term argv[])
         case Popcorn2EtsOverflow:
             RAISE_ERROR(OVERFLOW_ATOM);
         default:
+            // unreachable
             AVM_ABORT();
     }
 }
@@ -803,6 +805,7 @@ static term nif_ets_update_element(Context *ctx, int argc, term argv[])
         case Popcorn2EtsAllocationError:
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
+            // unreachable
             AVM_ABORT();
     }
 }
@@ -830,7 +833,7 @@ static term nif_ets_lookup_element(Context *ctx, int argc, term argv[])
 
     term ret = term_invalid_term();
 
-    Popcorn2EtsStatus result = popcorn2_ets_lookup_element(name_or_ref, key, (size_t) index, &ret, ctx);
+    Popcorn2EtsStatus result = popcorn2_ets_lookup_element_maybe_gc(name_or_ref, key, (size_t) index, &ret, ctx);
 
     switch (result) {
         case Popcorn2EtsOk:
@@ -846,6 +849,7 @@ static term nif_ets_lookup_element(Context *ctx, int argc, term argv[])
         case Popcorn2EtsAllocationError:
             RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
+            // unreachable
             AVM_ABORT();
     }
 }

--- a/src/libAtomVM/popcorn/popcorn_nifs.c
+++ b/src/libAtomVM/popcorn/popcorn_nifs.c
@@ -751,6 +751,8 @@ static term nif_ets_update_counter(Context *ctx, int argc, term argv[])
     term key = argv[1];
     term operation = argv[2];
    
+    VALIDATE_VALUE(name_or_ref, is_ets_table_id);
+
     term default_tuple = term_invalid_term();
     if (argc == 4) {
         default_tuple = argv[3];
@@ -786,6 +788,8 @@ static term nif_ets_update_element(Context *ctx, int argc, term argv[])
     term key = argv[1];
     term element_spec = argv[2];
    
+    VALIDATE_VALUE(name_or_ref, is_ets_table_id);
+
     term default_tuple = term_invalid_term();
     if (argc == 4) {
         default_tuple = argv[3];
@@ -875,6 +879,8 @@ static term nif_ets_delete(Context *ctx, int argc, term argv[])
             return TRUE_ATOM;
         case Popcorn2EtsBadAccess:
             RAISE_ERROR(BADARG_ATOM);
+        case Popcorn2EtsAllocationError:
+            RAISE_ERROR(OUT_OF_MEMORY_ATOM);
         default:
             // unreachable
             AVM_ABORT();

--- a/src/libAtomVM/popcorn/popcorn_nifs.c
+++ b/src/libAtomVM/popcorn/popcorn_nifs.c
@@ -696,9 +696,7 @@ static term nif_ets_member(Context *ctx, int argc, term argv[])
 
     VALIDATE_VALUE(name_or_ref, is_ets_table_id);
 
-    term ret = term_invalid_term();
-
-    Popcorn2EtsStatus result = popcorn2_ets_lookup_maybe_gc(name_or_ref, key, &ret, ctx);
+    Popcorn2EtsStatus result = popcorn2_ets_member(name_or_ref, key, ctx);
 
     switch (result) {
         case Popcorn2EtsOk:

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -202,6 +202,7 @@ test_lookup_element() ->
     [value2] = ets:lookup_element(DB, key2, PosValue),
 
     % Badargs
+    assert_badarg(fun() -> ets:lookup_element(bad_table, key, 1) end),
     AssertBadArgs(ets:new(test, [set])),
     AssertBadArgs(ets:new(test, [bag])),
     AssertBadArgs(ets:new(test, [duplicate_bag])),
@@ -223,6 +224,9 @@ test_member() ->
     DB = new_table(duplicate_bag, [{key, value}, {key, value}]),
     true = ets:member(DB, key),
     false = ets:member(DB, key_not_exist),
+
+    % Badargs
+    assert_badarg(fun() -> ets:member(bad_table, key) end),
 
     ok.
 
@@ -396,10 +400,7 @@ test_update_element() ->
     [{key_not_exist, new_value1, new_last_value2}] = ets:lookup(S6, key_not_exist),
 
     % Badargs
-
-    TErr = ets:new(test, [set, {keypos, 3}]),
-    true = ets:insert(TErr, {value1, value2, key}),
-
+    TErr = new_table(3, [{value1, value2, key}]),
     OkDefault = {value, value, value},
 
     % The table type is not set
@@ -407,6 +408,7 @@ test_update_element() ->
     TErrDuplBag = ets:new(test, [duplicate_bag]),
     assert_badarg(fun() -> ets:update_element(TErrBag, key, {1, value}) end),
     assert_badarg(fun() -> ets:update_element(TErrDuplBag, key, {1, value}) end),
+    assert_badarg(fun() -> ets:update_element(bad_table, key, {2, value}) end),
 
     % Pos < 1
     assert_badarg(fun() -> ets:update_element(TErr, key, {-1, pos_neg}) end),
@@ -489,12 +491,12 @@ test_update_counter() ->
     [{key_not_exist, 15, 20, 30}] = ets:lookup(S10, key_not_exist),
 
     % Badargs
-
     % The table type is not set
     TErrBag = ets:new(test, [bag]),
     TErrDuplBag = ets:new(test, [duplicate_bag]),
     assert_badarg(fun() -> ets:update_counter(TErrBag, key, 10) end),
     assert_badarg(fun() -> ets:update_counter(TErrDuplBag, key, 10) end),
+    assert_badarg(fun() -> ets:update_counter(bad_table, key, 10) end),
 
     TErr = new_table(2, {0, key, not_number}),
 
@@ -582,6 +584,9 @@ test_take() ->
     [] = ets:lookup(DB2, key),
     [{key2, value2}] = ets:lookup(DB2, key2),
 
+    % Badargs
+    assert_badarg(fun() -> ets:take(bad_table, key) end),
+
     ok.
 
 test_delete() ->
@@ -630,9 +635,9 @@ test_delete() ->
     % Badargs
     TErr = new_table(2, []),
     true = ets:delete(TErr),
+    assert_badarg(fun() -> ets:delete(bad_table) end),
     assert_badarg(fun() -> ets:lookup(TErr, key) end),
     assert_badarg(fun() -> ets:delete(TErr) end),
-    assert_badarg(fun() -> ets:delete(bad_table) end),
 
     ok.
 
@@ -681,11 +686,11 @@ test_delete_object() ->
 
     % Badargs
     TErr = new_table(2, []),
+    assert_badarg(fun() -> ets:delete_object(bad_table, {key, value}) end),
     assert_badarg(fun() -> ets:delete_object(TErr, not_a_tuple) end),
     assert_badarg(fun() -> ets:delete_object(TErr, [{key, value}, {key, value2}]) end),
     assert_badarg(fun() -> ets:delete_object(TErr, {}) end),
     assert_badarg(fun() -> ets:delete_object(TErr, {bad_keypos}) end),
-    assert_badarg(fun() -> ets:delete_object(bad_table, {key, value}) end),
 
     ok.
 

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -27,12 +27,8 @@ start() ->
     ok = isolated(fun test_permissions/0),
     ok = isolated(fun test_keys/0),
     ok = isolated(fun test_keypos/0),
-    ok = isolated(fun test_insert_set/0),
-    ok = isolated(fun test_insert_bag/0),
-    ok = isolated(fun test_insert_duplicate_bag/0),
-    ok = isolated(fun test_insert_new_set/0),
-    ok = isolated(fun test_insert_new_bag/0),
-    ok = isolated(fun test_insert_new_duplicate_bag/0),
+    ok = isolated(fun test_insert/0),
+    ok = isolated(fun test_insert_new/0),
     ok = isolated(fun test_delete/0),
     ok = isolated(fun test_delete_object/0),
     ok = isolated(fun test_lookup_element/0),
@@ -158,183 +154,144 @@ test_keypos() ->
     assert_badarg(fun() -> ets:insert(T, {value}) end),
     ok.
 
-test_insert_set() ->
-    T = ets:new(test, []),
-    [] = ets:lookup(T, key),
-    true = ets:insert(T, {key, value}),
-    [{key, value}] = ets:lookup(T, key),
-    % Overwrite
-    true = ets:insert(T, {key, new_value}),
-    [{key, new_value}] = ets:lookup(T, key),
+test_insert() ->
+    % Set
+    S1 = ets:new(test, []),
+    [] = ets:lookup(S1, key),
 
-    TList = ets:new(test, []),
-    true = ets:insert(TList, []),
-    true = ets:insert(TList, [{key, value}, {key2, value2}]),
-    true = ets:insert(TList, [{key2, new_value2}, {key3, value3}]),
-    [{key, value}] = ets:lookup(TList, key),
-    [{key2, new_value2}] = ets:lookup(TList, key2),
-    [{key3, value3}] = ets:lookup(TList, key3),
+    % {Key, Value}
+    true = ets:insert(S1, {key, value}),
+    [{key, value}] = ets:lookup(S1, key),
+    true = ets:insert(S1, {key, new_value}),
+    [{key, new_value}] = ets:lookup(S1, key),
 
-    TErr = ets:new(test, []),
-    assert_badarg(fun() -> ets:insert(TErr, {}) end),
-    assert_badarg(fun() -> ets:insert(TErr, [{}]) end),
-    assert_badarg(fun() -> ets:insert(TErr, [{key, value}, not_a_tuple]) end),
-    assert_badarg(fun() -> ets:insert(TErr, [{improper, true} | {list, true}]) end),
-    assert_badarg(fun() -> ets:insert(TErr, not_a_tuple) end),
-    assert_badarg(fun() -> ets:insert([not_a_ref], {key, value}) end),
-    [] = ets:lookup(TErr, key),
-    [] = ets:lookup(TErr, improper),
-    [] = ets:lookup(TErr, list),
+    % [{Key, Value}, ...]
+    S2 = ets:new(test, []),
+    true = ets:insert(S2, []),
+    true = ets:insert(S2, [{key, value}, {key2, value2}]),
+    true = ets:insert(S2, [{key2, new_value2}, {key3, value3}]),
+    [{key, value}] = ets:lookup(S2, key),
+    [{key2, new_value2}] = ets:lookup(S2, key2),
+    [{key3, value3}] = ets:lookup(S2, key3),
+
+    % Bag
+    B1 = ets:new(test, [bag]),
+    [] = ets:lookup(B1, key),
+
+    % {Key, Value}
+    true = ets:insert(B1, {key, value}),
+    [{key, value}] = ets:lookup(B1, key),
+    true = ets:insert(B1, {key, new_value}),
+    [{key, value}, {key, new_value}] = ets:lookup(B1, key),
+    true = ets:insert(B1, {key, new_value}),
+    [{key, value}, {key, new_value}] = ets:lookup(B1, key),
+
+    % [{Key, Value}, ...]
+    B2 = ets:new(test, [bag]),
+    true = ets:insert(B2, []),
+    true = ets:insert(B2, [{key, value}, {key2, value2}]),
+    true = ets:insert(B2, [{key2, new_value2}, {key3, value3}]),
+    true = ets:insert(B2, [{key2, new_value2}, {key3, new_value3}]),
+    [{key, value}] = ets:lookup(B2, key),
+    [{key2, value2}, {key2, new_value2}] = ets:lookup(B2, key2),
+    [{key3, value3}, {key3, new_value3}] = ets:lookup(B2, key3),
+
+    % Duplicate bag
+    DB1 = ets:new(test, [duplicate_bag]),
+    [] = ets:lookup(DB1, key),
+
+    % {Key, Value}
+    true = ets:insert(DB1, {key, value}),
+    [{key, value}] = ets:lookup(DB1, key),
+    true = ets:insert(DB1, {key, new_value}),
+    [{key, value}, {key, new_value}] = ets:lookup(DB1, key),
+    true = ets:insert(DB1, {key, new_value}),
+    [{key, value}, {key, new_value}, {key, new_value}] = ets:lookup(DB1, key),
+
+    % [{Key, Value}, ...]
+    DB2 = ets:new(test, [duplicate_bag]),
+    true = ets:insert(DB2, []),
+    true = ets:insert(DB2, [{key, value}, {key2, value2}]),
+    true = ets:insert(DB2, [{key2, new_value2}, {key3, value3}]),
+    true = ets:insert(DB2, [{key2, new_value2}, {key3, new_value3}]),
+    [{key, value}] = ets:lookup(DB2, key),
+    [{key2, value2}, {key2, new_value2}, {key2, new_value2}] = ets:lookup(DB2, key2),
+    [{key3, value3}, {key3, new_value3}] = ets:lookup(DB2, key3),
+
+    % Badargs
+    assert_insert_badargs(ets:new(test, []), fun ets:insert/2),
+    assert_insert_badargs(ets:new(test, [bag]), fun ets:insert/2),
+    assert_insert_badargs(ets:new(test, [duplicate_bag]), fun ets:insert/2),
+
     ok.
 
-test_insert_bag() ->
-    T = ets:new(test, [bag]),
-    [] = ets:lookup(T, key),
-    true = ets:insert(T, {key, value}),
-    [{key, value}] = ets:lookup(T, key),
-    true = ets:insert(T, {key, new_value}),
-    [{key, value}, {key, new_value}] = ets:lookup(T, key),
-    true = ets:insert(T, {key, new_value}),
-    [{key, value}, {key, new_value}] = ets:lookup(T, key),
+test_insert_new() ->
+    % Set
+    S1 = ets:new(test, []),
+    [] = ets:lookup(S1, key),
 
-    TList = ets:new(test, [bag]),
-    true = ets:insert(TList, []),
-    true = ets:insert(TList, [{key, value}, {key2, value2}]),
-    true = ets:insert(TList, [{key2, new_value2}, {key3, value3}]),
-    true = ets:insert(TList, [{key2, new_value2}, {key3, new_value3}]),
-    [{key, value}] = ets:lookup(TList, key),
-    [{key2, value2}, {key2, new_value2}] = ets:lookup(TList, key2),
-    [{key3, value3}, {key3, new_value3}] = ets:lookup(TList, key3),
+    % {Key, Value}
+    true = ets:insert_new(S1, {key, value}),
+    [{key, value}] = ets:lookup(S1, key),
+    false = ets:insert_new(S1, {key, new_value}),
+    [{key, value}] = ets:lookup(S1, key),
 
-    TErr = ets:new(test, [bag]),
-    assert_badarg(fun() -> ets:insert(TErr, {}) end),
-    assert_badarg(fun() -> ets:insert(TErr, [{}]) end),
-    assert_badarg(fun() -> ets:insert(TErr, [{key, value}, not_a_tuple]) end),
-    assert_badarg(fun() -> ets:insert(TErr, [{improper, true} | {list, true}]) end),
-    assert_badarg(fun() -> ets:insert(TErr, not_a_tuple) end),
-    assert_badarg(fun() -> ets:insert([not_a_ref], {key, value}) end),
-    [] = ets:lookup(TErr, key),
-    [] = ets:lookup(TErr, improper),
-    [] = ets:lookup(TErr, list),
-    ok.
+    % [{Key, Value}, ...]
+    S2 = ets:new(test, []),
+    true = ets:insert_new(S2, []),
+    true = ets:insert_new(S2, [{key, value}, {key2, value2}]),
+    false = ets:insert_new(S2, [{key2, new_value2}, {key3, value3}]),
+    [{key, value}] = ets:lookup(S2, key),
+    [{key2, value2}] = ets:lookup(S2, key2),
+    [] = ets:lookup(S2, key3),
 
-test_insert_duplicate_bag() ->
-    T = ets:new(test, [duplicate_bag]),
-    [] = ets:lookup(T, key),
-    true = ets:insert(T, {key, value}),
-    [{key, value}] = ets:lookup(T, key),
-    true = ets:insert(T, {key, new_value}),
-    [{key, value}, {key, new_value}] = ets:lookup(T, key),
-    true = ets:insert(T, {key, new_value}),
-    [{key, value}, {key, new_value}, {key, new_value}] = ets:lookup(T, key),
+    % Bag
+    B1 = ets:new(test, [bag]),
+    [] = ets:lookup(B1, key),
 
-    TList = ets:new(test, [duplicate_bag]),
-    true = ets:insert(TList, []),
-    true = ets:insert(TList, [{key, value}, {key2, value2}]),
-    true = ets:insert(TList, [{key2, new_value2}, {key3, value3}]),
-    true = ets:insert(TList, [{key2, new_value2}, {key3, new_value3}]),
-    [{key, value}] = ets:lookup(TList, key),
-    [{key2, value2}, {key2, new_value2}, {key2, new_value2}] = ets:lookup(TList, key2),
-    [{key3, value3}, {key3, new_value3}] = ets:lookup(TList, key3),
+    % {Key, Value}
+    true = ets:insert_new(B1, {key, value}),
+    [{key, value}] = ets:lookup(B1, key),
+    false = ets:insert_new(B1, {key, new_value}),
+    [{key, value}] = ets:lookup(B1, key),
 
-    TErr = ets:new(test, [duplicate_bag]),
-    assert_badarg(fun() -> ets:insert(TErr, {}) end),
-    assert_badarg(fun() -> ets:insert(TErr, [{}]) end),
-    assert_badarg(fun() -> ets:insert(TErr, [{key, value}, not_a_tuple]) end),
-    assert_badarg(fun() -> ets:insert(TErr, [{improper, true} | {list, true}]) end),
-    assert_badarg(fun() -> ets:insert(TErr, not_a_tuple) end),
-    assert_badarg(fun() -> ets:insert([not_a_ref], {key, value}) end),
-    [] = ets:lookup(TErr, key),
-    [] = ets:lookup(TErr, improper),
-    [] = ets:lookup(TErr, list),
-    ok.
+    % [{Key, Value}, ...]
+    B2 = ets:new(test, [bag]),
+    true = ets:insert_new(B2, []),
+    true = ets:insert_new(B2, [{key, value}, {key2, value2}]),
+    false = ets:insert_new(B2, [{key2, new_value2}, {key3, value3}]),
+    true = ets:insert_new(B2, [{key4, value4}, {key3, value3}, {key4, new_value4}]),
+    [{key, value}] = ets:lookup(B2, key),
+    [{key2, value2}] = ets:lookup(B2, key2),
+    [{key3, value3}] = ets:lookup(B2, key3),
+    [{key4, value4}, {key4, new_value4}] = ets:lookup(B2, key4),
 
-test_insert_new_set() ->
-    T = ets:new(test, []),
-    [] = ets:lookup(T, key),
-    true = ets:insert_new(T, {key, value}),
-    [{key, value}] = ets:lookup(T, key),
-    false = ets:insert_new(T, {key, new_value}),
-    [{key, value}] = ets:lookup(T, key),
+    % Duplicate bag
+    DB1 = ets:new(test, [duplicate_bag]),
+    [] = ets:lookup(DB1, key),
 
-    TList = ets:new(test, []),
-    true = ets:insert_new(TList, []),
-    true = ets:insert_new(TList, [{key, value}, {key2, value2}]),
-    false = ets:insert_new(TList, [{key2, new_value2}, {key3, value3}]),
-    [{key, value}] = ets:lookup(TList, key),
-    [{key2, value2}] = ets:lookup(TList, key2),
-    [] = ets:lookup(TList, key3),
+    % {Key, Value}
+    true = ets:insert_new(DB1, {key, value}),
+    [{key, value}] = ets:lookup(DB1, key),
+    false = ets:insert_new(DB1, {key, new_value}),
+    [{key, value}] = ets:lookup(DB1, key),
 
-    TErr = ets:new(test, []),
-    assert_badarg(fun() -> ets:insert_new(TErr, {}) end),
-    assert_badarg(fun() -> ets:insert_new(TErr, [{}]) end),
-    assert_badarg(fun() -> ets:insert_new(TErr, [{key, value}, not_a_tuple]) end),
-    assert_badarg(fun() -> ets:insert_new(TErr, [{improper, true} | {list, true}]) end),
-    assert_badarg(fun() -> ets:insert_new(TErr, not_a_tuple) end),
-    assert_badarg(fun() -> ets:insert_new([not_a_ref], {key, value}) end),
-    [] = ets:lookup(TErr, key),
-    [] = ets:lookup(TErr, improper),
-    [] = ets:lookup(TErr, list),
-    ok.
+    % [{Key, Value}, ...]
+    DB2 = ets:new(test, [duplicate_bag]),
+    true = ets:insert_new(DB2, []),
+    true = ets:insert_new(DB2, [{key, value}, {key2, value2}]),
+    false = ets:insert_new(DB2, [{key2, new_value2}, {key3, value3}]),
+    true = ets:insert_new(DB2, [{key4, value4}, {key3, value3}, {key4, value4}]),
+    [{key, value}] = ets:lookup(DB2, key),
+    [{key2, value2}] = ets:lookup(DB2, key2),
+    [{key3, value3}] = ets:lookup(DB2, key3),
+    [{key4, value4}, {key4, value4}] = ets:lookup(DB2, key4),
 
-test_insert_new_bag() ->
-    T = ets:new(test, [bag]),
-    [] = ets:lookup(T, key),
-    true = ets:insert_new(T, {key, value}),
-    [{key, value}] = ets:lookup(T, key),
-    false = ets:insert_new(T, {key, new_value}),
-    [{key, value}] = ets:lookup(T, key),
+    % Badargs
+    assert_insert_badargs(ets:new(test, []), fun ets:insert_new/2),
+    assert_insert_badargs(ets:new(test, [bag]), fun ets:insert_new/2),
+    assert_insert_badargs(ets:new(test, [duplicate_bag]), fun ets:insert_new/2),
 
-    TList = ets:new(test, [bag]),
-    true = ets:insert_new(TList, []),
-    true = ets:insert_new(TList, [{key, value}, {key2, value2}]),
-    false = ets:insert_new(TList, [{key2, new_value2}, {key3, value3}]),
-    true = ets:insert_new(TList, [{key4, value4}, {key3, value3}, {key4, new_value4}]),
-    [{key, value}] = ets:lookup(TList, key),
-    [{key2, value2}] = ets:lookup(TList, key2),
-    [{key3, value3}] = ets:lookup(TList, key3),
-    [{key4, value4}, {key4, new_value4}] = ets:lookup(TList, key4),
-
-    TErr = ets:new(test, [bag]),
-    assert_badarg(fun() -> ets:insert_new(TErr, {}) end),
-    assert_badarg(fun() -> ets:insert_new(TErr, [{}]) end),
-    assert_badarg(fun() -> ets:insert_new(TErr, [{key, value}, not_a_tuple]) end),
-    assert_badarg(fun() -> ets:insert_new(TErr, [{improper, true} | {list, true}]) end),
-    assert_badarg(fun() -> ets:insert_new(TErr, not_a_tuple) end),
-    assert_badarg(fun() -> ets:insert_new([not_a_ref], {key, value}) end),
-    [] = ets:lookup(TErr, key),
-    [] = ets:lookup(TErr, improper),
-    [] = ets:lookup(TErr, list),
-    ok.
-
-test_insert_new_duplicate_bag() ->
-    T = ets:new(test, [duplicate_bag]),
-    [] = ets:lookup(T, key),
-    true = ets:insert_new(T, {key, value}),
-    [{key, value}] = ets:lookup(T, key),
-    false = ets:insert_new(T, {key, new_value}),
-    [{key, value}] = ets:lookup(T, key),
-
-    TList = ets:new(test, [duplicate_bag]),
-    true = ets:insert_new(TList, []),
-    true = ets:insert_new(TList, [{key, value}, {key2, value2}]),
-    false = ets:insert_new(TList, [{key2, new_value2}, {key3, value3}]),
-    true = ets:insert_new(TList, [{key4, value4}, {key3, value3}, {key4, value4}]),
-    [{key, value}] = ets:lookup(TList, key),
-    [{key2, value2}] = ets:lookup(TList, key2),
-    [{key3, value3}] = ets:lookup(TList, key3),
-    [{key4, value4}, {key4, value4}] = ets:lookup(TList, key4),
-
-    TErr = ets:new(test, [duplicate_bag]),
-    assert_badarg(fun() -> ets:insert_new(TErr, {}) end),
-    assert_badarg(fun() -> ets:insert_new(TErr, [{}]) end),
-    assert_badarg(fun() -> ets:insert_new(TErr, [{key, value}, not_a_tuple]) end),
-    assert_badarg(fun() -> ets:insert_new(TErr, [{improper, true} | {list, true}]) end),
-    assert_badarg(fun() -> ets:insert_new(TErr, not_a_tuple) end),
-    assert_badarg(fun() -> ets:insert_new([not_a_ref], {key, value}) end),
-    [] = ets:lookup(TErr, key),
-    [] = ets:lookup(TErr, improper),
-    [] = ets:lookup(TErr, list),
     ok.
 
 test_delete() ->
@@ -386,6 +343,7 @@ test_delete() ->
     assert_badarg(fun() -> ets:lookup(TErr, key) end),
     assert_badarg(fun() -> ets:delete(TErr) end),
     assert_badarg(fun() -> ets:delete(bad_table) end),
+
     ok.
 
 test_delete_object() ->
@@ -438,6 +396,7 @@ test_delete_object() ->
     assert_badarg(fun() -> ets:delete_object(TErr, {}) end),
     assert_badarg(fun() -> ets:delete_object(TErr, {bad_keypos}) end),
     assert_badarg(fun() -> ets:delete_object(bad_table, {key, value}) end),
+
     ok.
 
 test_lookup_element() ->
@@ -727,6 +686,18 @@ test_take() ->
     [] = ets:lookup(DB2, key),
     [{key2, value2}] = ets:lookup(DB2, key2),
 
+    ok.
+
+assert_insert_badargs(T, Insert) ->
+    assert_badarg(fun() -> Insert(T, {}) end),
+    assert_badarg(fun() -> Insert(T, [{}]) end),
+    assert_badarg(fun() -> Insert(T, [{key, value}, not_a_tuple]) end),
+    assert_badarg(fun() -> Insert(T, [{improper, true} | {list, true}]) end),
+    assert_badarg(fun() -> Insert(T, not_a_tuple) end),
+    assert_badarg(fun() -> Insert([not_a_ref], {key, value}) end),
+    [] = ets:lookup(T, key),
+    [] = ets:lookup(T, improper),
+    [] = ets:lookup(T, list),
     ok.
 
 %%-----------------------------------------------------------------------------

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -27,15 +27,15 @@ start() ->
     ok = isolated(fun test_permissions/0),
     ok = isolated(fun test_keys/0),
     ok = isolated(fun test_keypos/0),
+    ok = isolated(fun test_lookup_element/0),
+    ok = isolated(fun test_member/0),
     ok = isolated(fun test_insert/0),
     ok = isolated(fun test_insert_new/0),
-    ok = isolated(fun test_delete/0),
-    ok = isolated(fun test_delete_object/0),
-    ok = isolated(fun test_lookup_element/0),
     ok = isolated(fun test_update_element/0),
     ok = isolated(fun test_update_counter/0),
-    ok = isolated(fun test_member/0),
     ok = isolated(fun test_take/0),
+    ok = isolated(fun test_delete/0),
+    ok = isolated(fun test_delete_object/0),
     0.
 
 test_ets_new() ->
@@ -416,40 +416,41 @@ test_lookup_element() ->
             assert_badarg(fun() -> ets:lookup_element(Tab, key, PosNegative, default) end)
         end,
 
-    % set
-    S = ets:new(test, []),
-    true = ets:insert(S, {key, value}),
+    % Set
+    S = new_table([{key, value}]),
     key = ets:lookup_element(S, key, PosKey),
     value = ets:lookup_element(S, key, PosValue),
     default = ets:lookup_element(S, key_not_exist, PosKey, default),
-    AssertBadArgs(S),
 
-    % bag
-    B = ets:new(test, [bag]),
-    true = ets:insert(B, {key, value}),
-    true = ets:insert(B, {key, value2}),
+    % Bag
+    B = new_table(bag, [{key, value}, {key, value2}]),
     [key, key] = ets:lookup_element(B, key, PosKey),
     [value, value2] = ets:lookup_element(B, key, PosValue),
     default = ets:lookup_element(B, key_not_exist, PosKey, default),
+
     true = ets:insert(B, {key, value3}),
     [key, key, key] = ets:lookup_element(B, key, PosKey),
     [value, value2, value3] = ets:lookup_element(B, key, PosValue),
-    AssertBadArgs(B),
 
-    % duplicate_bag
-    DB = ets:new(test, [duplicate_bag]),
-    true = ets:insert(DB, {key, value}),
-    true = ets:insert(DB, {key, value}),
+    % Duplicate bag
+    DB = new_table(duplicate_bag, [{key, value}, {key, value}]),
     [key, key] = ets:lookup_element(DB, key, PosKey),
     [value, value] = ets:lookup_element(DB, key, PosValue),
     default = ets:lookup_element(DB, key_not_exist, PosKey, default),
+
     true = ets:insert(DB, {key, value2}),
     [key, key, key] = ets:lookup_element(DB, key, PosKey),
     [value, value, value2] = ets:lookup_element(DB, key, PosValue),
+
     true = ets:insert(DB, {key2, value2}),
     [key2] = ets:lookup_element(DB, key2, PosKey),
     [value2] = ets:lookup_element(DB, key2, PosValue),
-    AssertBadArgs(DB),
+
+    % Badargs
+    AssertBadArgs(ets:new(test, [set])),
+    AssertBadArgs(ets:new(test, [bag])),
+    AssertBadArgs(ets:new(test, [duplicate_bag])),
+
     ok.
 
 test_update_element() ->

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -338,10 +338,9 @@ test_insert_new_duplicate_bag() ->
     ok.
 
 test_delete() ->
-    % set
-    S = ets:new(test, [set]),
+    % Set
+    S = new_table([{key, value}, {key2, value2}]),
     true = ets:delete(S, key_not_exist),
-    true = ets:insert(S, [{key, value}, {key2, value2}]),
 
     true = ets:delete(S, key),
     [] = ets:lookup(S, key),
@@ -349,14 +348,13 @@ test_delete() ->
 
     true = ets:delete(S, key2),
     [] = ets:lookup(S, key2),
-    true = ets:delete(S, key2),
 
+    true = ets:delete(S, key2),
     true = ets:delete(S),
 
-    % bag
-    B = ets:new(test, [bag]),
+    % Bag
+    B = new_table(bag, [{key, value}, {key, value2}, {key2, value3}]),
     true = ets:delete(B, key_not_exist),
-    true = ets:insert(B, [{key, value}, {key, value2}, {key2, value3}]),
 
     true = ets:delete(B, key),
     [] = ets:lookup(B, key),
@@ -364,14 +362,13 @@ test_delete() ->
 
     true = ets:delete(B, key2),
     [] = ets:lookup(B, key2),
-    true = ets:delete(B, key2),
 
+    true = ets:delete(B, key2),
     true = ets:delete(B),
 
-    % duplicate_bag
-    DB = ets:new(test, [duplicate_bag]),
+    % Duplicate bag
+    DB = new_table(duplicate_bag, [{key, value}, {key, value}, {key2, value2}]),
     true = ets:delete(DB, key_not_exist),
-    true = ets:insert(DB, [{key, value}, {key, value}, {key2, value2}]),
 
     true = ets:delete(DB, key),
     [] = ets:lookup(DB, key),
@@ -379,12 +376,12 @@ test_delete() ->
 
     true = ets:delete(DB, key2),
     [] = ets:lookup(DB, key2),
-    true = ets:delete(DB, key2),
 
+    true = ets:delete(DB, key2),
     true = ets:delete(DB),
 
-    % badargs
-    TErr = ets:new(test, [{keypos, 2}]),
+    % Badargs
+    TErr = new_table(2, []),
     true = ets:delete(TErr),
     assert_badarg(fun() -> ets:lookup(TErr, key) end),
     assert_badarg(fun() -> ets:delete(TErr) end),
@@ -392,56 +389,50 @@ test_delete() ->
     ok.
 
 test_delete_object() ->
-    % set
-    S = ets:new(test, [set]),
-    true = ets:insert(S, [{key, value}, {key2, value2}]),
-
+    % Set
+    S = new_table([{key, value}, {key2, value2}]),
     true = ets:delete_object(S, {key_not_exist, value_not_exist}),
+
+    true = ets:delete_object(S, {key, value_not_exist}),
     [{key, value}] = ets:lookup(S, key),
-    [{key2, value2}] = ets:lookup(S, key2),
 
     true = ets:delete_object(S, {key, value}),
     [] = ets:lookup(S, key),
-    [{key2, value2}] = ets:lookup(S, key2),
-
-    true = ets:delete_object(S, {key2, value_not_exist}),
-    [{key2, value2}] = ets:lookup(S, key2),
 
     true = ets:delete_object(S, {key2, value2}),
     [] = ets:lookup(S, key2),
 
-    % bag
-    B = ets:new(test, [bag]),
-    true = ets:insert(B, [{key, value}, {key, value2}, {key2, value2}]),
-
-    true = ets:delete_object(B, {key, value2}),
-    [{key, value}] = ets:lookup(B, key),
+    % Bag
+    B = new_table(bag, [{key, value}, {key, value2}, {key2, value2}]),
+    true = ets:delete_object(B, {key_not_exist, value_not_exist}),
 
     true = ets:delete_object(B, {key, value_not_exist}),
-    [{key, value}] = ets:lookup(B, key),
+    [{key, value}, {key, value2}] = ets:lookup(B, key),
 
     true = ets:delete_object(B, {key, value}),
+    [{key, value2}] = ets:lookup(B, key),
+
+    true = ets:delete_object(B, {key, value2}),
     [] = ets:lookup(B, key),
 
-    [{key2, value2}] = ets:lookup(B, key2),
     true = ets:delete_object(B, {key2, value2}),
     [] = ets:lookup(B, key2),
 
-    % duplicate_bag
-    DB = ets:new(test, [duplicate_bag]),
-    true = ets:insert(DB, [{key, value}, {key, value2}, {key, value}]),
+    % Duplicate bag
+    DB = new_table(duplicate_bag, [{key, value}, {key, value}, {key, value2}]),
+    true = ets:delete_object(DB, {key_not_exist, value_not_exist}),
+
+    true = ets:delete_object(DB, {key, value_not_exist}),
+    [{key, value}, {key, value}, {key, value2}] = ets:lookup(DB, key),
 
     true = ets:delete_object(DB, {key, value}),
     [{key, value2}] = ets:lookup(DB, key),
 
-    true = ets:delete_object(DB, {key, value_not_exist}),
-    [{key, value2}] = ets:lookup(DB, key),
-
     true = ets:delete_object(DB, {key, value2}),
-    [] = ets:lookup(DB, key2),
+    [] = ets:lookup(DB, key),
 
-    % badargs
-    TErr = ets:new(test, [{keypos, 2}]),
+    % Badargs
+    TErr = new_table(2, []),
     assert_badarg(fun() -> ets:delete_object(TErr, not_a_tuple) end),
     assert_badarg(fun() -> ets:delete_object(TErr, [{key, value}, {key, value2}]) end),
     assert_badarg(fun() -> ets:delete_object(TErr, {}) end),
@@ -691,17 +682,17 @@ test_update_counter() ->
     ok.
 
 test_member() ->
-    % set
+    % Set
     S = new_table([{key, value}]),
     true = ets:member(S, key),
     false = ets:member(S, key_not_exist),
 
-    % bag
+    % Bag
     B = new_table(bag, [{key, value}, {key, value2}]),
     true = ets:member(B, key),
     false = ets:member(B, key_not_exist),
 
-    % duplicate_bag
+    % Duplicate bag
     DB = new_table(duplicate_bag, [{key, value}, {key, value}]),
     true = ets:member(DB, key),
     false = ets:member(DB, key_not_exist),
@@ -709,7 +700,7 @@ test_member() ->
     ok.
 
 test_take() ->
-    % set
+    % Set
     S1 = new_table([]),
     [] = ets:take(S1, key_not_exist),
 
@@ -718,7 +709,7 @@ test_take() ->
     [] = ets:lookup(S2, key),
     [{key2, value2}] = ets:lookup(S2, key2),
 
-    % bag
+    % Bag
     B1 = new_table(bag, []),
     [] = ets:take(B1, key_not_exist),
 
@@ -727,7 +718,7 @@ test_take() ->
     [] = ets:lookup(B2, key),
     [{key2, value3}] = ets:lookup(B2, key2),
 
-    % duplicate_bag
+    % Duplicate bag
     DB1 = new_table(duplicate_bag, []),
     [] = ets:take(DB1, key_not_exist),
 

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -503,37 +503,30 @@ test_lookup_element() ->
     ok.
 
 test_update_element() ->
-    TableWithTuples = 
-        fun (Type, Tuples) ->
-            T = ets:new(test, [Type]),
-            true = ets:insert(T, Tuples),
-            T
-        end,
-
     % {Position, Value}
-    S1 = TableWithTuples(set, {key, value1, value2}),
+    S1 = new_table({key, value1, value2}),
     true = ets:update_element(S1, key, {2, new_value1}),
     [{key, new_value1, value2}] = ets:lookup(S1, key),
 
-    S2 = TableWithTuples(set, {key, value1, value2}),
+    S2 = new_table({key, value1, value2}),
     true = ets:update_element(S2, key, {3, new_value2}),
     [{key, value1, new_value2}] = ets:lookup(S2, key),
 
-    S3 = TableWithTuples(set, {key, value1, value2}),
+    S3 = new_table({key, value1, value2}),
     false = ets:update_element(S3, key_not_exist, {2, new_value1}),
     [{key, value1, value2}] = ets:lookup(S3, key),
 
     % [{Position, Value}, ...]
-    S4 = TableWithTuples(set, {key, value1, value2}),
+    S4 = new_table({key, value1, value2}),
     true = ets:update_element(S4, key, [{3, new_value2}, {2, new_value1}, {3, new_last_value2}]),
     [{key, new_value1, new_last_value2}] = ets:lookup(S4, key),
 
     % Default object
-    S5 = TableWithTuples(set, {key, value1, value2}),
+    S5 = new_table({key, value1, value2}),
     true = ets:update_element(S5, key_not_exist, {2, new_value1}, {key, value1, value2}),
     [{key_not_exist, new_value1, value2}] = ets:lookup(S5, key_not_exist),
 
-    S6 = TableWithTuples(set, {key, value1, value2}),
+    S6 = new_table({key, value1, value2}),
     true = ets:update_element(S6, key_not_exist,
         [{2, new_value1}, {3, new_value2}, {3, new_last_value2}], {key, value1, value2}),
     [{key_not_exist, new_value1, new_last_value2}] = ets:lookup(S6, key_not_exist),
@@ -582,58 +575,51 @@ test_update_element() ->
     ok.
 
 test_update_counter() ->
-    TableWithTuples =
-        fun (Keypos, Tuples) ->
-            T = ets:new(test, [set, {keypos, Keypos}]),
-            true = ets:insert(T, Tuples),
-            T
-        end,
-
     % Increment
-    S1 = TableWithTuples(1, {key, 10, not_number, 30}),
+    S1 = new_table({key, 10, not_number, 30}),
     15 = ets:update_counter(S1, key, 5),
     [{key, 15, not_number, 30}] = ets:lookup(S1, key),
 
-    S2 = TableWithTuples(3, {not_number, 20, key, 30}),
+    S2 = new_table(3, {not_number, 20, key, 30}),
     -5 = ets:update_counter(S2, key, -35),
     [{not_number, 20, key, -5}] = ets:lookup(S2, key),
 
     % {Position, Increment}
-    S3 = TableWithTuples(1, {key, 10, 20, not_number}),
+    S3 = new_table({key, 10, 20, not_number}),
     25 = ets:update_counter(S3, key, {3, 5}),
     [{key, 10, 25, not_number}] = ets:lookup(S3, key),
 
-    S4 = TableWithTuples(1, {key, 10, not_number, 30}),
+    S4 = new_table({key, 10, not_number, 30}),
     0 = ets:update_counter(S4, key, {2, -10}),
     [{key, 0, not_number, 30}] = ets:lookup(S4, key),
 
     % []
-    S5 = TableWithTuples(1, {key, 10, not_number, 30}),
+    S5 = new_table({key, 10, not_number, 30}),
     [] = ets:update_counter(S5, key, []),
     [{key, 10, not_number, 30}] = ets:lookup(S5, key),
 
     % [{Position, Increment}, ...]
-    S6 = TableWithTuples(1, {key, 10, 20, not_number}),
+    S6 = new_table({key, 10, 20, not_number}),
     [0, 5, 30] = ets:update_counter(S6, key, [{2, -10}, {2, 5}, {3, 10}]),
     [{key, 5, 30, not_number}] = ets:lookup(S6, key),
 
     % {Position, Increment, Threshold, SetValue}
-    S7 = TableWithTuples(1, {key, not_number, 20, 30}),
+    S7 = new_table({key, not_number, 20, 30}),
     31 = ets:update_counter(S7, key, {4, 10, 39, 31}),
     [{key, not_number, 20, 31}] = ets:lookup(S7, key),
 
-    S8 = TableWithTuples(1, {key, 10, not_number, 30}),
+    S8 = new_table({key, 10, not_number, 30}),
     29 = ets:update_counter(S8, key, {4, -10, 21, 29}),
     [{key, 10, not_number, 29}] = ets:lookup(S8, key),
 
     % [{Position, Increment, Threshold, SetValue}, ...]
-    S9 = TableWithTuples(1, {key, 10, 20, not_number}),
+    S9 = new_table({key, 10, 20, not_number}),
     [20, 31, 26] = ets:update_counter(S9, key,
         [{2, 10, 20, 21}, {2, 10, 29, 31}, {3, 5, 24, 26}]),
     [{key, 31, 26, not_number}] = ets:lookup(S9, key),
 
     % Default object
-    S10 = TableWithTuples(1, {key, 10, 20, not_number}),
+    S10 = new_table({key, 10, 20, not_number}),
     15 = ets:update_counter(S10, key_not_exist, {2, 5}, {key, 10, 20, 30}),
     [{key, 10, 20, not_number}] = ets:lookup(S10, key),
     [{key_not_exist, 15, 20, 30}] = ets:lookup(S10, key_not_exist),
@@ -646,10 +632,10 @@ test_update_counter() ->
     assert_badarg(fun() -> ets:update_counter(TErrBag, key, 10) end),
     assert_badarg(fun() -> ets:update_counter(TErrDuplBag, key, 10) end),
 
-    TErr = TableWithTuples(2, {0, key, not_number}),
+    TErr = new_table(2, {0, key, not_number}),
 
     % Pos > KeyPos
-    TErrLastKey = TableWithTuples(2, {0, key}),
+    TErrLastKey = new_table(2, {0, key}),
     assert_badarg(fun() -> ets:update_counter(TErrLastKey, key, 10) end),
 
     % No object with the correct key exists and no default object was supplied
@@ -680,7 +666,7 @@ test_update_counter() ->
     assert_badarg(fun() -> ets:update_counter(TErr, key, {2, 10}) end),
     assert_badarg(fun() -> ets:update_counter(TErr, key, [{1, 10}, {2, 10}]) end),
 
-    TErrIntKey = TableWithTuples(2, {10, 0}),
+    TErrIntKey = new_table(2, {10, 0}),
     assert_badarg(fun() -> ets:update_counter(TErrIntKey, 0, {2, 10}) end),
     assert_badarg(fun() -> ets:update_counter(TErrIntKey, 0, [{1, 10}, {2, 10}]) end),
     [{10, 0}] = ets:lookup(TErrIntKey, 0),
@@ -705,61 +691,47 @@ test_update_counter() ->
     ok.
 
 test_member() ->
-    TableWithTuples =
-        fun (Type, Tuples) ->
-            T = ets:new(test, [Type]),
-            true = ets:insert(T, Tuples),
-            T
-        end,
-
     % set
-    S = TableWithTuples(set, [{key, value}]),
+    S = new_table([{key, value}]),
     true = ets:member(S, key),
     false = ets:member(S, key_not_exist),
 
     % bag
-    B = TableWithTuples(bag, [{key, value}, {key, value2}]),
+    B = new_table(bag, [{key, value}, {key, value2}]),
     true = ets:member(B, key),
     false = ets:member(B, key_not_exist),
 
     % duplicate_bag
-    DB = TableWithTuples(duplicate_bag, [{key, value}, {key, value}]),
+    DB = new_table(duplicate_bag, [{key, value}, {key, value}]),
     true = ets:member(DB, key),
     false = ets:member(DB, key_not_exist),
 
     ok.
 
 test_take() ->
-    TableWithTuples =
-        fun (Type, Tuples) ->
-            T = ets:new(test, [Type]),
-            true = ets:insert(T, Tuples),
-            T
-        end,
-
     % set
-    S1 = TableWithTuples(set, []),
+    S1 = new_table([]),
     [] = ets:take(S1, key_not_exist),
 
-    S2 = TableWithTuples(set, [{key, value}, {key2, value2}]),
+    S2 = new_table([{key, value}, {key2, value2}]),
     [{key, value}] = ets:take(S2, key),
     [] = ets:lookup(S2, key),
     [{key2, value2}] = ets:lookup(S2, key2),
 
     % bag
-    B1 = TableWithTuples(bag, []),
+    B1 = new_table(bag, []),
     [] = ets:take(B1, key_not_exist),
 
-    B2 = TableWithTuples(bag, [{key, value}, {key, value2}, {key2, value3}]),
+    B2 = new_table(bag, [{key, value}, {key, value2}, {key2, value3}]),
     [{key, value}, {key, value2}] = ets:take(B2, key),
     [] = ets:lookup(B2, key),
     [{key2, value3}] = ets:lookup(B2, key2),
 
     % duplicate_bag
-    DB1 = TableWithTuples(duplicate_bag, []),
+    DB1 = new_table(duplicate_bag, []),
     [] = ets:take(DB1, key_not_exist),
 
-    DB2 = TableWithTuples(duplicate_bag, [{key, value}, {key, value}, {key2, value2}]),
+    DB2 = new_table(duplicate_bag, [{key, value}, {key, value}, {key2, value2}]),
     [{key, value}, {key, value}] = ets:take(DB2, key),
     [] = ets:lookup(DB2, key),
     [{key2, value2}] = ets:lookup(DB2, key2),
@@ -792,6 +764,18 @@ assert_stored_key(T, Key) ->
     true = ets:insert(T, {Key, value}),
     [{Key, value}] = ets:lookup(T, Key),
     ok.
+
+new_table(Tuples) ->
+    new_table([], Tuples).
+
+new_table(Type, Tuples) when is_atom(Type) ->
+    new_table([Type], Tuples);
+new_table(Keypos, Tuples) when is_integer(Keypos) ->
+    new_table([{keypos, Keypos}], Tuples);
+new_table(Opts, Tuples) when is_list(Opts) ->
+    T = ets:new(test, Opts),
+    true = ets:insert(T, Tuples),
+    T.
 
 isolated(Fun) ->
     Ref = make_ref(),

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -38,6 +38,7 @@ start() ->
     ok = isolated(fun test_lookup_element/0),
     ok = isolated(fun test_update_element/0),
     ok = isolated(fun test_update_counter/0),
+    ok = isolated(fun test_member/0),
     ok = isolated(fun test_take/0),
     0.
 
@@ -700,6 +701,31 @@ test_update_counter() ->
     assert_badarg(fun() -> ets:update_counter(TErr, key, [{1, 10, 20, 30}, {1, 10, 20, not_number}]) end),
 
     [{0, key, not_number}] = ets:lookup(TErr, key),
+
+    ok.
+
+test_member() ->
+    TableWithTuples =
+        fun (Type, Tuples) ->
+            T = ets:new(test, [Type]),
+            true = ets:insert(T, Tuples),
+            T
+        end,
+
+    % set
+    S = TableWithTuples(set, [{key, value}]),
+    true = ets:member(S, key),
+    false = ets:member(S, key_not_exist),
+
+    % bag
+    B = TableWithTuples(bag, [{key, value}, {key, value2}]),
+    true = ets:member(B, key),
+    false = ets:member(B, key_not_exist),
+
+    % duplicate_bag
+    DB = TableWithTuples(duplicate_bag, [{key, value}, {key, value}]),
+    true = ets:member(DB, key),
+    false = ets:member(DB, key_not_exist),
 
     ok.
 

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -450,7 +450,7 @@ test_lookup_element() ->
             PosZero = 0,
             PosNegative = -1,
 
-            assert_badarg(fun() -> ets:lookup_element(Tab, bad_key, PosKey) end),
+            assert_badarg(fun() -> ets:lookup_element(Tab, key_not_exist, PosKey) end),
             assert_badarg(fun() -> ets:lookup_element(Tab, key, PosZero) end),
             assert_badarg(fun() -> ets:lookup_element(Tab, key, PosPastBounds) end),
             assert_badarg(fun() -> ets:lookup_element(Tab, key, PosNegative) end),
@@ -462,7 +462,7 @@ test_lookup_element() ->
     true = ets:insert(S, {key, value}),
     key = ets:lookup_element(S, key, PosKey),
     value = ets:lookup_element(S, key, PosValue),
-    default = ets:lookup_element(S, bad_key, PosKey, default),
+    default = ets:lookup_element(S, key_not_exist, PosKey, default),
     AssertBadArgs(S),
 
     % bag
@@ -471,7 +471,7 @@ test_lookup_element() ->
     true = ets:insert(B, {key, value2}),
     [key, key] = ets:lookup_element(B, key, PosKey),
     [value, value2] = ets:lookup_element(B, key, PosValue),
-    default = ets:lookup_element(B, bad_key, PosKey, default),
+    default = ets:lookup_element(B, key_not_exist, PosKey, default),
     true = ets:insert(B, {key, value3}),
     [key, key, key] = ets:lookup_element(B, key, PosKey),
     [value, value2, value3] = ets:lookup_element(B, key, PosValue),
@@ -483,7 +483,7 @@ test_lookup_element() ->
     true = ets:insert(DB, {key, value}),
     [key, key] = ets:lookup_element(DB, key, PosKey),
     [value, value] = ets:lookup_element(DB, key, PosValue),
-    default = ets:lookup_element(DB, bad_key, PosKey, default),
+    default = ets:lookup_element(DB, key_not_exist, PosKey, default),
     true = ets:insert(DB, {key, value2}),
     [key, key, key] = ets:lookup_element(DB, key, PosKey),
     [value, value, value2] = ets:lookup_element(DB, key, PosValue),

--- a/tests/erlang_tests/test_ets.erl
+++ b/tests/erlang_tests/test_ets.erl
@@ -154,6 +154,78 @@ test_keypos() ->
     assert_badarg(fun() -> ets:insert(T, {value}) end),
     ok.
 
+test_lookup_element() ->
+    PosKey = 1,
+    PosValue = 2,
+
+    AssertBadArgs =
+        fun(Tab) ->
+            PosPastBounds = 3,
+            PosZero = 0,
+            PosNegative = -1,
+
+            assert_badarg(fun() -> ets:lookup_element(Tab, key_not_exist, PosKey) end),
+            assert_badarg(fun() -> ets:lookup_element(Tab, key, PosZero) end),
+            assert_badarg(fun() -> ets:lookup_element(Tab, key, PosPastBounds) end),
+            assert_badarg(fun() -> ets:lookup_element(Tab, key, PosNegative) end),
+            assert_badarg(fun() -> ets:lookup_element(Tab, key, PosNegative, default) end)
+        end,
+
+    % Set
+    S = new_table([{key, value}]),
+    key = ets:lookup_element(S, key, PosKey),
+    value = ets:lookup_element(S, key, PosValue),
+    default = ets:lookup_element(S, key_not_exist, PosKey, default),
+
+    % Bag
+    B = new_table(bag, [{key, value}, {key, value2}]),
+    [key, key] = ets:lookup_element(B, key, PosKey),
+    [value, value2] = ets:lookup_element(B, key, PosValue),
+    default = ets:lookup_element(B, key_not_exist, PosKey, default),
+
+    true = ets:insert(B, {key, value3}),
+    [key, key, key] = ets:lookup_element(B, key, PosKey),
+    [value, value2, value3] = ets:lookup_element(B, key, PosValue),
+
+    % Duplicate bag
+    DB = new_table(duplicate_bag, [{key, value}, {key, value}]),
+    [key, key] = ets:lookup_element(DB, key, PosKey),
+    [value, value] = ets:lookup_element(DB, key, PosValue),
+    default = ets:lookup_element(DB, key_not_exist, PosKey, default),
+
+    true = ets:insert(DB, {key, value2}),
+    [key, key, key] = ets:lookup_element(DB, key, PosKey),
+    [value, value, value2] = ets:lookup_element(DB, key, PosValue),
+
+    true = ets:insert(DB, {key2, value2}),
+    [key2] = ets:lookup_element(DB, key2, PosKey),
+    [value2] = ets:lookup_element(DB, key2, PosValue),
+
+    % Badargs
+    AssertBadArgs(ets:new(test, [set])),
+    AssertBadArgs(ets:new(test, [bag])),
+    AssertBadArgs(ets:new(test, [duplicate_bag])),
+
+    ok.
+
+test_member() ->
+    % Set
+    S = new_table([{key, value}]),
+    true = ets:member(S, key),
+    false = ets:member(S, key_not_exist),
+
+    % Bag
+    B = new_table(bag, [{key, value}, {key, value2}]),
+    true = ets:member(B, key),
+    false = ets:member(B, key_not_exist),
+
+    % Duplicate bag
+    DB = new_table(duplicate_bag, [{key, value}, {key, value}]),
+    true = ets:member(DB, key),
+    false = ets:member(DB, key_not_exist),
+
+    ok.
+
 test_insert() ->
     % Set
     S1 = ets:new(test, []),
@@ -291,165 +363,6 @@ test_insert_new() ->
     assert_insert_badargs(ets:new(test, []), fun ets:insert_new/2),
     assert_insert_badargs(ets:new(test, [bag]), fun ets:insert_new/2),
     assert_insert_badargs(ets:new(test, [duplicate_bag]), fun ets:insert_new/2),
-
-    ok.
-
-test_delete() ->
-    % Set
-    S = new_table([{key, value}, {key2, value2}]),
-    true = ets:delete(S, key_not_exist),
-
-    true = ets:delete(S, key),
-    [] = ets:lookup(S, key),
-    [{key2, value2}] = ets:lookup(S, key2),
-
-    true = ets:delete(S, key2),
-    [] = ets:lookup(S, key2),
-
-    true = ets:delete(S, key2),
-    true = ets:delete(S),
-
-    % Bag
-    B = new_table(bag, [{key, value}, {key, value2}, {key2, value3}]),
-    true = ets:delete(B, key_not_exist),
-
-    true = ets:delete(B, key),
-    [] = ets:lookup(B, key),
-    [{key2, value3}] = ets:lookup(B, key2),
-
-    true = ets:delete(B, key2),
-    [] = ets:lookup(B, key2),
-
-    true = ets:delete(B, key2),
-    true = ets:delete(B),
-
-    % Duplicate bag
-    DB = new_table(duplicate_bag, [{key, value}, {key, value}, {key2, value2}]),
-    true = ets:delete(DB, key_not_exist),
-
-    true = ets:delete(DB, key),
-    [] = ets:lookup(DB, key),
-    [{key2, value2}] = ets:lookup(DB, key2),
-
-    true = ets:delete(DB, key2),
-    [] = ets:lookup(DB, key2),
-
-    true = ets:delete(DB, key2),
-    true = ets:delete(DB),
-
-    % Badargs
-    TErr = new_table(2, []),
-    true = ets:delete(TErr),
-    assert_badarg(fun() -> ets:lookup(TErr, key) end),
-    assert_badarg(fun() -> ets:delete(TErr) end),
-    assert_badarg(fun() -> ets:delete(bad_table) end),
-
-    ok.
-
-test_delete_object() ->
-    % Set
-    S = new_table([{key, value}, {key2, value2}]),
-    true = ets:delete_object(S, {key_not_exist, value_not_exist}),
-
-    true = ets:delete_object(S, {key, value_not_exist}),
-    [{key, value}] = ets:lookup(S, key),
-
-    true = ets:delete_object(S, {key, value}),
-    [] = ets:lookup(S, key),
-
-    true = ets:delete_object(S, {key2, value2}),
-    [] = ets:lookup(S, key2),
-
-    % Bag
-    B = new_table(bag, [{key, value}, {key, value2}, {key2, value2}]),
-    true = ets:delete_object(B, {key_not_exist, value_not_exist}),
-
-    true = ets:delete_object(B, {key, value_not_exist}),
-    [{key, value}, {key, value2}] = ets:lookup(B, key),
-
-    true = ets:delete_object(B, {key, value}),
-    [{key, value2}] = ets:lookup(B, key),
-
-    true = ets:delete_object(B, {key, value2}),
-    [] = ets:lookup(B, key),
-
-    true = ets:delete_object(B, {key2, value2}),
-    [] = ets:lookup(B, key2),
-
-    % Duplicate bag
-    DB = new_table(duplicate_bag, [{key, value}, {key, value}, {key, value2}]),
-    true = ets:delete_object(DB, {key_not_exist, value_not_exist}),
-
-    true = ets:delete_object(DB, {key, value_not_exist}),
-    [{key, value}, {key, value}, {key, value2}] = ets:lookup(DB, key),
-
-    true = ets:delete_object(DB, {key, value}),
-    [{key, value2}] = ets:lookup(DB, key),
-
-    true = ets:delete_object(DB, {key, value2}),
-    [] = ets:lookup(DB, key),
-
-    % Badargs
-    TErr = new_table(2, []),
-    assert_badarg(fun() -> ets:delete_object(TErr, not_a_tuple) end),
-    assert_badarg(fun() -> ets:delete_object(TErr, [{key, value}, {key, value2}]) end),
-    assert_badarg(fun() -> ets:delete_object(TErr, {}) end),
-    assert_badarg(fun() -> ets:delete_object(TErr, {bad_keypos}) end),
-    assert_badarg(fun() -> ets:delete_object(bad_table, {key, value}) end),
-
-    ok.
-
-test_lookup_element() ->
-    PosKey = 1,
-    PosValue = 2,
-
-    AssertBadArgs =
-        fun(Tab) ->
-            PosPastBounds = 3,
-            PosZero = 0,
-            PosNegative = -1,
-
-            assert_badarg(fun() -> ets:lookup_element(Tab, key_not_exist, PosKey) end),
-            assert_badarg(fun() -> ets:lookup_element(Tab, key, PosZero) end),
-            assert_badarg(fun() -> ets:lookup_element(Tab, key, PosPastBounds) end),
-            assert_badarg(fun() -> ets:lookup_element(Tab, key, PosNegative) end),
-            assert_badarg(fun() -> ets:lookup_element(Tab, key, PosNegative, default) end)
-        end,
-
-    % Set
-    S = new_table([{key, value}]),
-    key = ets:lookup_element(S, key, PosKey),
-    value = ets:lookup_element(S, key, PosValue),
-    default = ets:lookup_element(S, key_not_exist, PosKey, default),
-
-    % Bag
-    B = new_table(bag, [{key, value}, {key, value2}]),
-    [key, key] = ets:lookup_element(B, key, PosKey),
-    [value, value2] = ets:lookup_element(B, key, PosValue),
-    default = ets:lookup_element(B, key_not_exist, PosKey, default),
-
-    true = ets:insert(B, {key, value3}),
-    [key, key, key] = ets:lookup_element(B, key, PosKey),
-    [value, value2, value3] = ets:lookup_element(B, key, PosValue),
-
-    % Duplicate bag
-    DB = new_table(duplicate_bag, [{key, value}, {key, value}]),
-    [key, key] = ets:lookup_element(DB, key, PosKey),
-    [value, value] = ets:lookup_element(DB, key, PosValue),
-    default = ets:lookup_element(DB, key_not_exist, PosKey, default),
-
-    true = ets:insert(DB, {key, value2}),
-    [key, key, key] = ets:lookup_element(DB, key, PosKey),
-    [value, value, value2] = ets:lookup_element(DB, key, PosValue),
-
-    true = ets:insert(DB, {key2, value2}),
-    [key2] = ets:lookup_element(DB, key2, PosKey),
-    [value2] = ets:lookup_element(DB, key2, PosValue),
-
-    % Badargs
-    AssertBadArgs(ets:new(test, [set])),
-    AssertBadArgs(ets:new(test, [bag])),
-    AssertBadArgs(ets:new(test, [duplicate_bag])),
 
     ok.
 
@@ -641,24 +554,6 @@ test_update_counter() ->
 
     ok.
 
-test_member() ->
-    % Set
-    S = new_table([{key, value}]),
-    true = ets:member(S, key),
-    false = ets:member(S, key_not_exist),
-
-    % Bag
-    B = new_table(bag, [{key, value}, {key, value2}]),
-    true = ets:member(B, key),
-    false = ets:member(B, key_not_exist),
-
-    % Duplicate bag
-    DB = new_table(duplicate_bag, [{key, value}, {key, value}]),
-    true = ets:member(DB, key),
-    false = ets:member(DB, key_not_exist),
-
-    ok.
-
 test_take() ->
     % Set
     S1 = new_table([]),
@@ -686,6 +581,111 @@ test_take() ->
     [{key, value}, {key, value}] = ets:take(DB2, key),
     [] = ets:lookup(DB2, key),
     [{key2, value2}] = ets:lookup(DB2, key2),
+
+    ok.
+
+test_delete() ->
+    % Set
+    S = new_table([{key, value}, {key2, value2}]),
+    true = ets:delete(S, key_not_exist),
+
+    true = ets:delete(S, key),
+    [] = ets:lookup(S, key),
+    [{key2, value2}] = ets:lookup(S, key2),
+
+    true = ets:delete(S, key2),
+    [] = ets:lookup(S, key2),
+
+    true = ets:delete(S, key2),
+    true = ets:delete(S),
+
+    % Bag
+    B = new_table(bag, [{key, value}, {key, value2}, {key2, value3}]),
+    true = ets:delete(B, key_not_exist),
+
+    true = ets:delete(B, key),
+    [] = ets:lookup(B, key),
+    [{key2, value3}] = ets:lookup(B, key2),
+
+    true = ets:delete(B, key2),
+    [] = ets:lookup(B, key2),
+
+    true = ets:delete(B, key2),
+    true = ets:delete(B),
+
+    % Duplicate bag
+    DB = new_table(duplicate_bag, [{key, value}, {key, value}, {key2, value2}]),
+    true = ets:delete(DB, key_not_exist),
+
+    true = ets:delete(DB, key),
+    [] = ets:lookup(DB, key),
+    [{key2, value2}] = ets:lookup(DB, key2),
+
+    true = ets:delete(DB, key2),
+    [] = ets:lookup(DB, key2),
+
+    true = ets:delete(DB, key2),
+    true = ets:delete(DB),
+
+    % Badargs
+    TErr = new_table(2, []),
+    true = ets:delete(TErr),
+    assert_badarg(fun() -> ets:lookup(TErr, key) end),
+    assert_badarg(fun() -> ets:delete(TErr) end),
+    assert_badarg(fun() -> ets:delete(bad_table) end),
+
+    ok.
+
+test_delete_object() ->
+    % Set
+    S = new_table([{key, value}, {key2, value2}]),
+    true = ets:delete_object(S, {key_not_exist, value_not_exist}),
+
+    true = ets:delete_object(S, {key, value_not_exist}),
+    [{key, value}] = ets:lookup(S, key),
+
+    true = ets:delete_object(S, {key, value}),
+    [] = ets:lookup(S, key),
+
+    true = ets:delete_object(S, {key2, value2}),
+    [] = ets:lookup(S, key2),
+
+    % Bag
+    B = new_table(bag, [{key, value}, {key, value2}, {key2, value2}]),
+    true = ets:delete_object(B, {key_not_exist, value_not_exist}),
+
+    true = ets:delete_object(B, {key, value_not_exist}),
+    [{key, value}, {key, value2}] = ets:lookup(B, key),
+
+    true = ets:delete_object(B, {key, value}),
+    [{key, value2}] = ets:lookup(B, key),
+
+    true = ets:delete_object(B, {key, value2}),
+    [] = ets:lookup(B, key),
+
+    true = ets:delete_object(B, {key2, value2}),
+    [] = ets:lookup(B, key2),
+
+    % Duplicate bag
+    DB = new_table(duplicate_bag, [{key, value}, {key, value}, {key, value2}]),
+    true = ets:delete_object(DB, {key_not_exist, value_not_exist}),
+
+    true = ets:delete_object(DB, {key, value_not_exist}),
+    [{key, value}, {key, value}, {key, value2}] = ets:lookup(DB, key),
+
+    true = ets:delete_object(DB, {key, value}),
+    [{key, value2}] = ets:lookup(DB, key),
+
+    true = ets:delete_object(DB, {key, value2}),
+    [] = ets:lookup(DB, key),
+
+    % Badargs
+    TErr = new_table(2, []),
+    assert_badarg(fun() -> ets:delete_object(TErr, not_a_tuple) end),
+    assert_badarg(fun() -> ets:delete_object(TErr, [{key, value}, {key, value2}]) end),
+    assert_badarg(fun() -> ets:delete_object(TErr, {}) end),
+    assert_badarg(fun() -> ets:delete_object(TErr, {bad_keypos}) end),
+    assert_badarg(fun() -> ets:delete_object(bad_table, {key, value}) end),
 
     ok.
 


### PR DESCRIPTION
This PR implements the `member/2` function and adds following changes:

- Refactor and deduplicate tests
- Fix memory leaks, use-after-free, use-after-gc bugs
- Fix hash function bugs
- Add missing input validation and error handling in nifs
- Remove dead code